### PR TITLE
docs: add README, LICENSE, and npm package metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 itguy614
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 itguy614
+Copyright (c) 2026 Kurt Wolf
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# Clean UI
+
+[![npm](https://img.shields.io/npm/v/@itguy614/clean-ui.svg)](https://www.npmjs.com/package/@itguy614/clean-ui)
+[![license](https://img.shields.io/npm/l/@itguy614/clean-ui.svg)](./LICENSE)
+[![docs](https://img.shields.io/badge/docs-live-blue.svg)](https://itguy614.github.io/clean-ui/)
+
+A clean, dark-mode-ready **Vue 3** component library — 100+ components on a fully
+token-driven theme system. Subtle by default, bold by choice; accessible first;
+overridable at every level via CSS custom properties.
+
+**[📖 Documentation & live examples →](https://itguy614.github.io/clean-ui/)**
+
+## Install
+
+```sh
+npm install @itguy614/clean-ui vue@^3.5
+```
+
+```ts
+import { createCleanUI } from "@itguy614/clean-ui";
+import "@itguy614/clean-ui/styles";
+
+createApp(App).use(createCleanUI()).mount("#app");
+```
+
+Full install, usage, and theming guide: [`packages/clean-ui/README.md`](./packages/clean-ui/README.md).
+
+## Highlights
+
+- **100+ components** across layout, form controls, actions, feedback, data display, navigation, overlays.
+- **8 themes** + light/dark, driven by `--cui-*` tokens — override on `:root` or any scope.
+- **Accessible first**, **TypeScript**-native, **Tailwind v4** compatible, tree-shakeable ESM.
+
+## Repository structure
+
+This is a pnpm monorepo:
+
+| Path | Description |
+|---|---|
+| `packages/clean-ui` | The published library (`@itguy614/clean-ui`) |
+| `apps/docs` | The documentation site (dogfoods the library), deployed to GitHub Pages |
+| `scripts` | Tooling (e.g. `check-contrast.mjs` — WCAG audit across themes) |
+
+## Development
+
+```sh
+pnpm install
+
+# build the library (Vite + vue-tsc declarations)
+pnpm --filter @itguy614/clean-ui build
+
+# run the docs site locally
+pnpm --filter docs dev
+
+# audit color contrast across all themes
+node scripts/check-contrast.mjs
+```
+
+Conventions, architecture, and the component checklist live in [`CLAUDE.md`](./CLAUDE.md).
+
+## License
+
+[MIT](./LICENSE) © itguy614

--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ Conventions, architecture, and the component checklist live in [`CLAUDE.md`](./C
 
 ## License
 
-[MIT](./LICENSE) © itguy614
+[MIT](./LICENSE) © Kurt Wolf

--- a/packages/clean-ui/LICENSE
+++ b/packages/clean-ui/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 itguy614
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/clean-ui/LICENSE
+++ b/packages/clean-ui/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 itguy614
+Copyright (c) 2026 Kurt Wolf
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/clean-ui/README.md
+++ b/packages/clean-ui/README.md
@@ -113,4 +113,4 @@ Full component reference, props, and live examples: **https://itguy614.github.io
 
 ## License
 
-[MIT](./LICENSE) © itguy614
+[MIT](./LICENSE) © Kurt Wolf

--- a/packages/clean-ui/README.md
+++ b/packages/clean-ui/README.md
@@ -1,0 +1,116 @@
+# @itguy614/clean-ui
+
+[![npm](https://img.shields.io/npm/v/@itguy614/clean-ui.svg)](https://www.npmjs.com/package/@itguy614/clean-ui)
+[![license](https://img.shields.io/npm/l/@itguy614/clean-ui.svg)](./LICENSE)
+[![docs](https://img.shields.io/badge/docs-live-blue.svg)](https://itguy614.github.io/clean-ui/)
+
+A clean, dark-mode-ready Vue 3 component library. 100+ components built on a fully
+token-driven theme system — **subtle by default, bold by choice**, accessible first,
+and overridable at every level via CSS custom properties.
+
+**[📖 Documentation & live examples →](https://itguy614.github.io/clean-ui/)**
+
+## Features
+
+- **100+ components** — layout, form controls, actions, feedback, data display, navigation, and overlays.
+- **8 built-in themes** + light/dark mode, all driven by `--cui-*` custom properties you can override on any scope.
+- **Accessible first** — WCAG AA contrast targets, ARIA attributes, keyboard navigation, focus management.
+- **TypeScript** — full type definitions; shared `CuiColor` / `CuiSize` / `CuiRounded` prop types across components.
+- **Tailwind CSS v4 compatible** — color scales registered via `@theme` so Tailwind utilities work alongside the components.
+- **Tree-shakeable ESM** (+ CJS build), Vue as the only peer dependency.
+
+## Installation
+
+```sh
+npm install @itguy614/clean-ui
+# peer dependency
+npm install vue@^3.5
+```
+
+## Quick start
+
+Register the plugin (registers every `Cui*` component globally) and import the stylesheet once:
+
+```ts
+// main.ts
+import { createApp } from "vue";
+import { createCleanUI } from "@itguy614/clean-ui";
+import "@itguy614/clean-ui/styles";
+import App from "./App.vue";
+
+createApp(App).use(createCleanUI()).mount("#app");
+```
+
+```vue
+<template>
+  <CuiButton color="primary" variant="solid">Click me</CuiButton>
+</template>
+```
+
+### Or import components individually
+
+No plugin required — import only what you use:
+
+```vue
+<script setup lang="ts">
+import { CuiButton, CuiCard, CuiCardBody } from "@itguy614/clean-ui";
+import "@itguy614/clean-ui/styles";
+</script>
+
+<template>
+  <CuiCard>
+    <CuiCardBody>
+      <CuiButton>Hello</CuiButton>
+    </CuiCardBody>
+  </CuiCard>
+</template>
+```
+
+## Theming
+
+Eight presets ship out of the box: **Navy** (default), Mono, Forest, Amber, Azure, Teal, Violet, and Ruby.
+Themes are plain CSS classes — apply one to any ancestor (or `<html>`) and everything inside re-themes:
+
+```html
+<html class="cui-theme-forest">      <!-- whole app -->
+<div class="cui-theme-violet"> … </div>  <!-- scoped subtree -->
+```
+
+Dark mode is the `dark` class on any ancestor:
+
+```html
+<html class="dark cui-theme-azure"> … </html>
+```
+
+Switch themes reactively with the `useTheme` composable (persists to `localStorage`):
+
+```ts
+import { useTheme } from "@itguy614/clean-ui";
+
+const { theme, setTheme } = useTheme();
+setTheme("forest");
+```
+
+### Customizing tokens
+
+Every color, radius, and typography value is a `--cui-*` custom property. Override on `:root` or any scoped container:
+
+```css
+:root {
+  --cui-button-radius: 0.5rem;
+}
+
+/* Or re-map a whole color scale for a custom brand theme */
+.cui-theme-brand {
+  --color-primary-500: oklch(0.5 0.2 320);
+  /* …50–950 */
+}
+```
+
+## Documentation
+
+Full component reference, props, and live examples: **https://itguy614.github.io/clean-ui/**
+
+## License
+
+[MIT](./LICENSE) © itguy614

--- a/packages/clean-ui/package.json
+++ b/packages/clean-ui/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "A clean, dark-mode-ready Vue 3 component library — 100+ token-driven, themeable, accessible components.",
   "license": "MIT",
-  "author": "itguy614",
+  "author": "Kurt Wolf",
   "homepage": "https://itguy614.github.io/clean-ui/",
   "repository": {
     "type": "git",

--- a/packages/clean-ui/package.json
+++ b/packages/clean-ui/package.json
@@ -2,9 +2,30 @@
   "name": "@itguy614/clean-ui",
   "version": "0.3.1",
   "type": "module",
-  "description": "A clean, dark-mode-ready Vue UI component library",
+  "description": "A clean, dark-mode-ready Vue 3 component library — 100+ token-driven, themeable, accessible components.",
   "license": "MIT",
   "author": "itguy614",
+  "homepage": "https://itguy614.github.io/clean-ui/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/itguy614/clean-ui.git",
+    "directory": "packages/clean-ui"
+  },
+  "bugs": {
+    "url": "https://github.com/itguy614/clean-ui/issues"
+  },
+  "keywords": [
+    "vue",
+    "vue3",
+    "component-library",
+    "components",
+    "ui",
+    "design-system",
+    "tailwindcss",
+    "dark-mode",
+    "typescript",
+    "accessible"
+  ],
   "main": "./dist/clean-ui.umd.cjs",
   "module": "./dist/clean-ui.js",
   "types": "./dist/index.d.ts",
@@ -17,7 +38,9 @@
     "./styles": "./dist/clean-ui.css"
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
   "sideEffects": [
     "**/*.css"


### PR DESCRIPTION
Closes #5.

## What
Gives the package a proper front door for adoption.

- **Root `README.md`** — overview, install, quick start, highlights, monorepo structure, dev commands, docs link.
- **`packages/clean-ui/README.md`** (npm-facing) — install, quick start (plugin + `@itguy614/clean-ui/styles`), individual-import usage, theming (8 presets via `cui-theme-*`, dark mode, `useTheme`), token customization, docs link, badges.
- **`LICENSE`** (MIT) at repo root and in the package — the `license` field claimed MIT but no file existed.
- **`package.json` metadata** — `homepage` (docs site), `repository` (+`directory`), `bugs`, `keywords`; added `README.md` + `LICENSE` to `files`.

## Acceptance criteria
- [x] Root README with install + quickstart + theming + docs link
- [x] README published in the npm tarball — verified with `npm pack --dry-run` (ships `README.md` + `LICENSE` alongside `dist/`)

No code changes; build unaffected.