### PR TITLE
chore: CONTRIBUTING.md + one-command component scaffold

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# Contributing to Clean UI
+
+Thanks for your interest in contributing! This guide covers setup, the day-to-day
+workflow, and the conventions that keep the library consistent.
+
+## Prerequisites
+
+- **Node** ≥ 20
+- **pnpm** ≥ 10 (this repo is a pnpm workspace — `npm`/`yarn` are not used)
+
+```sh
+pnpm install
+```
+
+## Repository layout
+
+| Path | Description |
+|---|---|
+| `packages/clean-ui` | The published library (`@itguy614/clean-ui`) |
+| `apps/docs` | Documentation site — it **dogfoods** the library and is deployed to GitHub Pages |
+| `scripts` | Tooling — `new-component.mjs` (scaffold), `check-contrast.mjs` (WCAG audit) |
+| `CLAUDE.md` | The canonical conventions & architecture reference — read it before building components |
+
+## Common commands
+
+```sh
+pnpm dev               # run the docs site locally (hot reload)
+pnpm build             # build the library (Vite + vue-tsc type declarations)
+pnpm test              # run the test suite (vitest)
+pnpm check:contrast    # audit color contrast across every theme
+```
+
+> **Heads-up:** the docs site consumes the *built* library. After changing library
+> source, run `pnpm build` and clear the docs cache: `rm -rf apps/docs/node_modules/.vite`.
+
+## Adding a new component
+
+Use the scaffold — it stamps the component, an optional context file, and a docs page,
+and wires everything up (library `index.ts` export + plugin registration, docs route, nav entry):
+
+```sh
+pnpm new:component SegmentedControl --group "Form Controls"
+# add --context to also generate a provide/inject context file
+```
+
+Valid `--group` values: `Layout`, `Form Controls`, `Actions`, `Feedback`, `Data Display`, `Navigation`, `Overlay`.
+
+Then implement the component following the conventions. The essentials (full checklist in [`CLAUDE.md`](./CLAUDE.md)):
+
+- **Compose shared prop mixins** from `types/common.ts` via `extends` — `HideableProps`,
+  `ColorableProps` (`color: CuiColor`), `SizeableProps` (`size: CuiSize`), `DisableableProps`,
+  `FormControlProps`. Don't re-declare these per component.
+- **Use the shared types** — `CuiColor`, `CuiSize`, `CuiRounded`, `CuiOrientation`. Import size
+  scales from `utils/sizing.ts` (and `clampSize` to narrow). Never define local size/color types or maps.
+- **Semantic tokens only** — `var(--cui-surface-base)`, `var(--cui-border)`, `var(--cui-{role})` /
+  `-bg` / `-border`. Never hardcode colors or use Tailwind color utilities (breaks theming),
+  and never use template literals for Tailwind classes (v4 can't detect them — use inline `:style`).
+- **Subtle by default, bold by choice** — resting states use tinted `-bg`/`-border`; solid fills only via `variant="solid"`.
+- **Accessible first** — `aria-*`, keyboard navigation, visible focus rings.
+- **`defineExpose({ el, focus, blur })`** on interactive components.
+- **Icons** via `CuiIcon` (never inline SVGs).
+- Document the component on its generated docs page (props table + examples using `CuiCard`/`Example`).
+
+Finish with a green `pnpm build` (zero TypeScript errors) and `pnpm test`.
+
+## Tests
+
+Tests live in `packages/clean-ui/src/components/__tests__` and run on vitest + `@vue/test-utils` + jsdom.
+New components should at least have a smoke test (mounts, renders, respects `hidden`/`disabled`);
+bug fixes should add a regression test where practical.
+
+## Commits & pull requests
+
+- **Branch from `develop`** and open PRs **against `develop`** (the integration branch). `master` tracks releases.
+- Keep PRs focused; reference the issue they address (e.g. `Closes #12`).
+- Use clear, conventional-style commit subjects (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`).
+- Ensure `pnpm build` and `pnpm test` pass. For visual changes, include before/after screenshots.
+- Be kind in reviews — we credit effort and iterate together. 💙
+
+## License
+
+By contributing, you agree your contributions are licensed under the [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -46,17 +46,14 @@ This is a pnpm monorepo:
 ```sh
 pnpm install
 
-# build the library (Vite + vue-tsc declarations)
-pnpm --filter @itguy614/clean-ui build
-
-# run the docs site locally
-pnpm --filter docs dev
-
-# audit color contrast across all themes
-node scripts/check-contrast.mjs
+pnpm dev               # run the docs site locally
+pnpm build             # build the library (Vite + vue-tsc declarations)
+pnpm test              # run the test suite
+pnpm new:component Foo --group "Form Controls"   # scaffold a new component
+pnpm check:contrast    # audit color contrast across all themes
 ```
 
-Conventions, architecture, and the component checklist live in [`CLAUDE.md`](./CLAUDE.md).
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the full workflow, and [`CLAUDE.md`](./CLAUDE.md) for conventions, architecture, and the component checklist.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "pnpm --filter @itguy614/clean-ui build",
     "build:docs": "pnpm --filter @itguy614/clean-ui-docs build",
     "test": "pnpm --filter @itguy614/clean-ui test",
-    "lint": "pnpm -r lint"
+    "lint": "pnpm -r lint",
+    "new:component": "node scripts/new-component.mjs",
+    "check:contrast": "node scripts/check-contrast.mjs"
   },
   "engines": {
     "node": ">=20",

--- a/scripts/new-component.mjs
+++ b/scripts/new-component.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+/**
+ * Scaffold a new Clean UI component following the project conventions.
+ *
+ *   node scripts/new-component.mjs <Name> [--context] [--group "<Group>"]
+ *
+ * Example:
+ *   node scripts/new-component.mjs Rating --group "Data Display"
+ *   node scripts/new-component.mjs SegmentedControl --context --group "Form Controls"
+ *
+ * Creates:
+ *   packages/clean-ui/src/components/Cui<Name>.vue
+ *   packages/clean-ui/src/components/<kebab>-context.ts        (with --context)
+ *   apps/docs/src/pages/<Name>Page.vue
+ * And wires up:
+ *   packages/clean-ui/src/index.ts        (import, export, type export, plugin)
+ *   apps/docs/src/router/index.ts         (route)
+ *   apps/docs/src/components/Navigation.vue (nav entry under --group)
+ *
+ * Run the library build afterwards: `npm run build -w packages/clean-ui`
+ */
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const GROUPS = ["Layout", "Form Controls", "Actions", "Feedback", "Data Display", "Navigation", "Overlay"];
+
+// ---- args ----
+const args = process.argv.slice(2);
+let rawName = "";
+let withContext = false;
+let group = "Layout";
+for (let i = 0; i < args.length; i++) {
+  const a = args[i];
+  if (a === "--context") withContext = true;
+  else if (a === "--group") group = args[++i];
+  else if (!a.startsWith("--")) rawName = a;
+}
+
+if (!rawName) {
+  console.error("Usage: node scripts/new-component.mjs <Name> [--context] [--group \"<Group>\"]");
+  process.exit(1);
+}
+if (!GROUPS.includes(group)) {
+  console.error(`Unknown --group "${group}". Valid groups:\n  ${GROUPS.join("\n  ")}`);
+  process.exit(1);
+}
+
+// ---- names ----
+const name = rawName.replace(/^Cui/, "").replace(/[^A-Za-z0-9]/g, "");
+if (!/^[A-Z][A-Za-z0-9]*$/.test(name)) {
+  console.error(`Name must be PascalCase (got "${rawName}").`);
+  process.exit(1);
+}
+const comp = `Cui${name}`;
+const kebab = name.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
+const label = name.replace(/([a-z0-9])([A-Z])/g, "$1 $2");
+const routePath = `/components/${kebab}`;
+
+const compFile = resolve(ROOT, `packages/clean-ui/src/components/${comp}.vue`);
+const ctxFile = resolve(ROOT, `packages/clean-ui/src/components/${kebab}-context.ts`);
+const pageFile = resolve(ROOT, `apps/docs/src/pages/${name}Page.vue`);
+const indexFile = resolve(ROOT, "packages/clean-ui/src/index.ts");
+const routerFile = resolve(ROOT, "apps/docs/src/router/index.ts");
+const navFile = resolve(ROOT, "apps/docs/src/components/Navigation.vue");
+
+if (existsSync(compFile)) {
+  console.error(`Refusing to overwrite existing component: ${comp}.vue`);
+  process.exit(1);
+}
+
+const sub = (tpl) =>
+  tpl
+    .replaceAll("__COMP__", comp)
+    .replaceAll("__NAME__", name)
+    .replaceAll("__KEBAB__", kebab)
+    .replaceAll("__LABEL__", label);
+
+// ---- templates ----
+const componentTpl = [
+  '<script setup lang="ts">',
+  'import { useTemplateRef } from "vue";',
+  'import type { HideableProps } from "../types/common";',
+  '// Compose more shared mixins as needed: ColorableProps (color: CuiColor),',
+  '// SizeableProps (size: CuiSize), DisableableProps (disabled), FormControlProps.',
+  '// For a size scale, narrow via clampSize() from "../utils/sizing".',
+  '',
+  'export interface __COMP__Props extends HideableProps {',
+  '  /** TODO: add component-specific props */',
+  '}',
+  '',
+  'withDefaults(defineProps<__COMP__Props>(), {',
+  '  hidden: false,',
+  '});',
+  '',
+  '// Interactive components expose an imperative handle:',
+  'const elRef = useTemplateRef<HTMLElement>("rootEl");',
+  'function focus(opts?: FocusOptions) { elRef.value?.focus(opts); }',
+  'function blur() { elRef.value?.blur(); }',
+  'defineExpose({ el: elRef, focus, blur });',
+  '</' + 'script>',
+  '',
+  '<template>',
+  '  <div ref="rootEl" v-show="!hidden" class="cui-__KEBAB__">',
+  '    <slot />',
+  '  </div>',
+  '</template>',
+  '',
+  '<style scoped>',
+  '/* Use semantic tokens only — var(--cui-surface-base), var(--cui-border),',
+  '   var(--cui-{role}) / -bg / -border. Never hardcode colors (breaks themes). */',
+  '.cui-__KEBAB__ {',
+  '  color: var(--cui-text-body);',
+  '}',
+  '</style>',
+  '',
+].join("\n");
+
+const contextTpl = [
+  'import type { InjectionKey, Ref } from "vue";',
+  '',
+  'export interface __NAME__Context {',
+  '  // shared reactive state provided to descendants, e.g.:',
+  '  // value: Ref<string | undefined>;',
+  '}',
+  '',
+  'export const __NAME__Key: InjectionKey<__NAME__Context> = Symbol("cui-__KEBAB__");',
+  '',
+].join("\n");
+
+const pageTpl = [
+  '<script setup lang="ts">',
+  'import { __COMP__, CuiStack } from "@itguy614/clean-ui";',
+  'import PropTable from "../components/PropTable.vue";',
+  'import Example from "../components/Example.vue";',
+  '</' + 'script>',
+  '',
+  '<template>',
+  '  <CuiStack spacing="8">',
+  '    <div>',
+  '      <h1 class="text-4xl font-bold">__LABEL__</h1>',
+  '      <p class="mt-2 text-lg text-surface-600 dark:text-surface-400">',
+  '        TODO: describe __LABEL__.',
+  '      </p>',
+  '    </div>',
+  '',
+  '    <div>',
+  '      <h2 class="mb-4 text-2xl font-semibold">Props</h2>',
+  '      <PropTable :props="[',
+  "        { name: 'hidden', type: 'boolean', default: 'false', description: 'Hide the component (v-show)' },",
+  '      ]" />',
+  '    </div>',
+  '',
+  '    <div>',
+  '      <h2 class="mb-4 text-2xl font-semibold">Examples</h2>',
+  '      <CuiStack spacing="6">',
+  '        <Example title="Basic" :code="`<__COMP__>Hello</__COMP__>`">',
+  '          <__COMP__>Hello</__COMP__>',
+  '        </Example>',
+  '      </CuiStack>',
+  '    </div>',
+  '  </CuiStack>',
+  '</template>',
+  '',
+].join("\n");
+
+// ---- write new files ----
+writeFileSync(compFile, sub(componentTpl));
+if (withContext) writeFileSync(ctxFile, sub(contextTpl));
+writeFileSync(pageFile, sub(pageTpl));
+
+// ---- wire up library index.ts ----
+{
+  const lines = readFileSync(indexFile, "utf8").split("\n");
+  const importRe = /^import Cui\w+ from "\.\/components\/Cui\w+\.vue";$/;
+  const typeRe = /^export type \{ Cui\w+Props.*\} from "\.\/components\/Cui\w+\.vue";$/;
+  const appRe = /^\s*app\.component\("Cui\w+", Cui\w+\);$/;
+  const lastIdx = (re) => { let n = -1; lines.forEach((l, i) => { if (re.test(l)) n = i; }); return n; };
+
+  lines.splice(lastIdx(importRe) + 1, 0, `import ${comp} from "./components/${comp}.vue";`);
+  lines.splice(lastIdx(typeRe) + 1, 0, `export type { ${comp}Props } from "./components/${comp}.vue";`);
+  lines.splice(lastIdx(appRe) + 1, 0, `      app.component("${comp}", ${comp});`);
+
+  // component export list (single long `export { ... };` line)
+  const expIdx = lines.findIndex((l) => l.startsWith("export {") && l.includes("Cui") && l.trimEnd().endsWith("};"));
+  lines[expIdx] = lines[expIdx].replace(/ \};\s*$/, `, ${comp} };`);
+
+  writeFileSync(indexFile, lines.join("\n"));
+}
+
+// ---- wire up docs router ----
+{
+  let txt = readFileSync(routerFile, "utf8");
+  const route = `    {\n      path: '${routePath}',\n      name: '${kebab}',\n      component: () => import('../pages/${name}Page.vue'),\n    },\n`;
+  txt = txt.replace(/(\n {2}routes: \[\n)/, `$1${route}`);
+  writeFileSync(routerFile, txt);
+}
+
+// ---- wire up docs nav (appends before sections `];`; groups via reduce so it lands at end of its group) ----
+{
+  let txt = readFileSync(navFile, "utf8");
+  const entry = `  { id: "${kebab}", label: "${label}", path: "${routePath}", group: "${group}" },\n`;
+  txt = txt.replace(/\n\];\n\nconst groupedSections/, `\n${entry}];\n\nconst groupedSections`);
+  writeFileSync(navFile, txt);
+}
+
+console.log(`✓ Created ${comp}`);
+console.log(`  • packages/clean-ui/src/components/${comp}.vue`);
+if (withContext) console.log(`  • packages/clean-ui/src/components/${kebab}-context.ts`);
+console.log(`  • apps/docs/src/pages/${name}Page.vue`);
+console.log(`  • registered in index.ts, router, and nav ("${group}")`);
+console.log(`\nNext:`);
+console.log(`  1. Implement ${comp}.vue (props, a11y, semantic tokens).`);
+console.log(`  2. Build the library:  npm run build -w packages/clean-ui`);
+console.log(`  3. Clear docs cache:   rm -rf apps/docs/node_modules/.vite`);
+console.log(`  4. Flesh out the docs page + PropTable.`);


### PR DESCRIPTION
Closes #13.

## What
Lowers the barrier to contribution and makes the conventions automatic.

### `pnpm new:component <Name> [--context] [--group "<Group>"]`
A zero-dependency scaffold (`scripts/new-component.mjs`) that:
- stamps `Cui<Name>.vue` (conventions-correct: `extends HideableProps`, `defineExpose`, semantic-token styles, hints for the other shared mixins),
- optionally a `<kebab>-context.ts` (`--context`),
- a docs page `<Name>Page.vue`,
- and **auto-wires** the library `index.ts` (import, export list, type export, plugin registration), the docs **router**, and the **nav** entry under `--group`.

Validated end-to-end: scaffolded a throwaway component, confirmed all six wirings, built the library green, then reverted.

### `CONTRIBUTING.md`
Setup, monorepo layout, common commands, the scaffold workflow, the convention checklist (shared mixins/types, semantic tokens, subtle-first, a11y, `defineExpose`), testing expectations, and the **branch-from / PR-to `develop`** process.

### Also
- Root scripts: `new:component`, `check:contrast`.
- README dev section now points at the root scripts and links `CONTRIBUTING.md` (also fixes the stale docs filter name).

## Acceptance criteria
- [x] CONTRIBUTING.md
- [x] One-command component scaffold that follows the conventions