### PR TITLE
feat(form): CuiForm form-level abstraction + validation integration

### DIFF
--- a/apps/docs/src/components/Navigation.vue
+++ b/apps/docs/src/components/Navigation.vue
@@ -31,6 +31,7 @@ const sections = [
   { id: "date-range-picker", label: "Date Range", path: "/components/date-range-picker", group: "Form Controls" },
   { id: "fieldset", label: "Fieldset", path: "/components/fieldset", group: "Form Controls" },
   { id: "file-upload", label: "File Upload", path: "/components/file-upload", group: "Form Controls" },
+  { id: "form", label: "Form", path: "/components/form", group: "Form Controls" },
   { id: "form-field", label: "Form Field", path: "/components/form-field", group: "Form Controls" },
   { id: "input", label: "Input", path: "/components/input", group: "Form Controls" },
   { id: "input-stepper", label: "Input Stepper", path: "/components/input-stepper", group: "Form Controls" },

--- a/apps/docs/src/pages/FormPage.vue
+++ b/apps/docs/src/pages/FormPage.vue
@@ -1,0 +1,234 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import {
+  CuiForm,
+  CuiFormField,
+  CuiInput,
+  CuiSelect,
+  CuiButton,
+  CuiStack,
+  CuiCard,
+  CuiCardBody,
+  CuiCardHeader,
+  CuiAlert,
+  type FormValues,
+  type FormErrors,
+} from "@itguy614/clean-ui";
+import PropTable from "../components/PropTable.vue";
+import EventTable from "../components/EventTable.vue";
+import Example from "../components/Example.vue";
+
+const roleOptions = [
+  { value: "engineering", label: "Engineering" },
+  { value: "design", label: "Design" },
+  { value: "product", label: "Product" },
+];
+
+// A plain hand-written resolver — no validation library needed. Returns an
+// errors map keyed by field name; an empty object means "valid".
+function resolver(values: FormValues): FormErrors {
+  const errors: FormErrors = {};
+  const email = String(values.email ?? "");
+  const password = String(values.password ?? "");
+  if (!email) errors.email = "Email is required";
+  else if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) errors.email = "Enter a valid email";
+  if (!values.role) errors.role = "Pick a role";
+  if (password.length < 8) errors.password = "Must be at least 8 characters";
+  return errors;
+}
+
+const formValues = ref<FormValues>({ email: "", role: null, password: "" });
+const result = ref("(submit the form)");
+
+function onSubmit(values: FormValues) {
+  result.value = `✅ Submitted: ${JSON.stringify(values)}`;
+}
+function onInvalid(errors: FormErrors) {
+  result.value = `❌ Invalid: ${Object.keys(errors).length} field(s) need attention`;
+}
+</script>
+
+<template>
+  <CuiStack spacing="8">
+    <div>
+      <h1 class="text-4xl font-bold">Form</h1>
+      <p class="mt-2 text-lg text-surface-600 dark:text-surface-400">
+        <code class="cui-code">CuiForm</code> adds a form-level layer over the field components:
+        value tracking, error aggregation, submit handling, and a library-agnostic validation
+        hook. Fields stay fully usable standalone — the form binding is opt-in via a
+        <code class="cui-code">name</code> on <code class="cui-code">CuiFormField</code>.
+      </p>
+    </div>
+
+    <!-- How binding works -->
+    <CuiCard variant="outline">
+      <CuiCardHeader title="How field binding works" />
+      <CuiCardBody>
+        <p class="text-sm" style="color: var(--cui-text-secondary);">
+          Give <code class="cui-code">CuiFormField</code> a <code class="cui-code">name</code> and
+          nest it in a <code class="cui-code">CuiForm</code>. The field then exposes ready-to-bind
+          props through its default slot — spread them onto any Cui field component with
+          <code class="cui-code">v-bind</code>:
+        </p>
+        <pre class="cui-pre" style="margin-top: 0.75rem;"><code class="cui-code">&lt;CuiForm :resolver="resolver" v-model="values" @submit="save"&gt;
+  &lt;CuiFormField name="email" label="Email" v-slot="f"&gt;
+    &lt;CuiInput v-bind="f" type="email" /&gt;
+  &lt;/CuiFormField&gt;
+&lt;/CuiForm&gt;
+
+// f = { id, modelValue, "onUpdate:modelValue", error, disabled }
+// CuiFormField renders the label + error message; the field shows the red border.</code></pre>
+      </CuiCardBody>
+    </CuiCard>
+
+    <!-- CuiForm props -->
+    <div>
+      <h2 class="mb-4 text-2xl font-semibold">CuiForm Props</h2>
+      <PropTable
+        :props="[
+          { name: 'modelValue', type: 'FormValues', default: '{}', description: 'Form values (v-model). Seeds initial values and stays in sync.' },
+          { name: 'resolver', type: '(values) => FormErrors | Promise<FormErrors>', default: '—', description: 'Library-agnostic validation. Returns an errors map keyed by field name; {} = valid.' },
+          { name: 'validateOn', type: 'submit | change', default: 'submit', description: '\'submit\' validates on submit then revalidates a field on change; \'change\' validates eagerly from the first keystroke.' },
+          { name: 'disabled', type: 'boolean', default: 'false', description: 'Disable every bound field.' },
+          { name: 'readonly', type: 'boolean', default: 'false', description: 'Mark every bound field readonly.' },
+          { name: 'hidden', type: 'boolean', default: 'false', description: 'Hide the form (v-show).' },
+        ]"
+      />
+      <p class="mt-3 text-sm" style="color: var(--cui-text-secondary);">
+        Exposes via <code class="cui-code">ref</code>: <code class="cui-code">validate()</code>,
+        <code class="cui-code">reset(values?)</code>, <code class="cui-code">submit()</code>,
+        plus reactive <code class="cui-code">values</code> and <code class="cui-code">errors</code>.
+        The default slot also receives <code class="cui-code">{ values, errors, submitted }</code>.
+      </p>
+    </div>
+
+    <!-- New CuiFormField props -->
+    <div>
+      <h2 class="mb-4 text-2xl font-semibold">CuiFormField — form binding</h2>
+      <PropTable
+        :props="[
+          { name: 'name', type: 'string', default: '—', description: 'Field name. With a name + a parent CuiForm, the field auto-binds value & error. Omit to use standalone.' },
+        ]"
+      />
+      <p class="mt-3 text-sm" style="color: var(--cui-text-secondary);">
+        All existing <code class="cui-code">CuiFormField</code> props (<code class="cui-code">label</code>,
+        <code class="cui-code">required</code>, <code class="cui-code">helpText</code>,
+        <code class="cui-code">error</code>, <code class="cui-code">errorMessage</code>, …) still work.
+        When form-bound, <code class="cui-code">error</code>/<code class="cui-code">errorMessage</code>
+        come from the form and the manual props are ignored.
+      </p>
+    </div>
+
+    <!-- Events -->
+    <div>
+      <h2 class="mb-4 text-2xl font-semibold">Events</h2>
+      <EventTable
+        :events="[
+          { name: 'submit', payload: 'FormValues', description: 'Fires after a submit that passed validation' },
+          { name: 'submit-invalid', payload: 'FormErrors', description: 'Fires after a submit that failed validation' },
+          { name: 'update:modelValue', payload: 'FormValues', description: 'Fires whenever a bound field changes' },
+        ]"
+      />
+    </div>
+
+    <!-- Live example -->
+    <div>
+      <h2 class="mb-4 text-2xl font-semibold">Examples</h2>
+      <CuiStack spacing="6">
+        <Example title="Validated form" :code="`<CuiForm :resolver=&quot;resolver&quot; v-model=&quot;values&quot;
+  @submit=&quot;onSubmit&quot; @submit-invalid=&quot;onInvalid&quot;>
+  <CuiFormField name=&quot;email&quot; label=&quot;Email&quot; required v-slot=&quot;f&quot;>
+    <CuiInput v-bind=&quot;f&quot; type=&quot;email&quot; placeholder=&quot;you@example.com&quot; />
+  </CuiFormField>
+
+  <CuiFormField name=&quot;role&quot; label=&quot;Role&quot; required v-slot=&quot;f&quot;>
+    <CuiSelect v-bind=&quot;f&quot; :options=&quot;roleOptions&quot; placeholder=&quot;Choose…&quot; />
+  </CuiFormField>
+
+  <CuiFormField name=&quot;password&quot; label=&quot;Password&quot; required
+    help-text=&quot;At least 8 characters&quot; v-slot=&quot;f&quot;>
+    <CuiInput v-bind=&quot;f&quot; type=&quot;password&quot; />
+  </CuiFormField>
+
+  <CuiButton type=&quot;submit&quot; variant=&quot;solid&quot;>Create account</CuiButton>
+</CuiForm>
+
+// validates on submit, then live-revalidates each field as you fix it`">
+          <CuiForm
+            :resolver="resolver"
+            v-model="formValues"
+            @submit="onSubmit"
+            @submit-invalid="onInvalid"
+          >
+            <CuiStack spacing="4">
+              <CuiFormField name="email" label="Email" required v-slot="f">
+                <CuiInput v-bind="f" type="email" placeholder="you@example.com" />
+              </CuiFormField>
+
+              <CuiFormField name="role" label="Role" required v-slot="f">
+                <CuiSelect v-bind="f" :options="roleOptions" placeholder="Choose…" />
+              </CuiFormField>
+
+              <CuiFormField name="password" label="Password" required help-text="At least 8 characters" v-slot="f">
+                <CuiInput v-bind="f" type="password" />
+              </CuiFormField>
+
+              <div>
+                <CuiButton type="submit" variant="solid" color="primary">Create account</CuiButton>
+              </div>
+
+              <CuiAlert :color="result.startsWith('✅') ? 'success' : result.startsWith('❌') ? 'error' : 'info'" variant="subtle" :title="result" />
+            </CuiStack>
+          </CuiForm>
+        </Example>
+
+        <!-- Validation recipes -->
+        <CuiCard variant="outline">
+          <CuiCardHeader title="Validation recipe: zod" />
+          <CuiCardBody>
+            <pre class="cui-pre"><code class="cui-code">import { z } from "zod";
+import { CuiForm, zodResolver } from "@itguy614/clean-ui";
+
+const schema = z.object({
+  email: z.string().email("Enter a valid email"),
+  role: z.string().min(1, "Pick a role"),
+  password: z.string().min(8, "Must be at least 8 characters"),
+});
+
+const resolver = zodResolver(schema);
+// &lt;CuiForm :resolver="resolver" /&gt;</code></pre>
+          </CuiCardBody>
+        </CuiCard>
+
+        <CuiCard variant="outline">
+          <CuiCardHeader title="Validation recipe: valibot" />
+          <CuiCardBody>
+            <pre class="cui-pre"><code class="cui-code">import * as v from "valibot";
+import { CuiForm, valibotResolver } from "@itguy614/clean-ui";
+
+const schema = v.object({
+  email: v.pipe(v.string(), v.email("Enter a valid email")),
+  role: v.pipe(v.string(), v.minLength(1, "Pick a role")),
+  password: v.pipe(v.string(), v.minLength(8, "Must be at least 8 characters")),
+});
+
+const resolver = valibotResolver((values) => v.safeParse(schema, values));
+// &lt;CuiForm :resolver="resolver" /&gt;</code></pre>
+          </CuiCardBody>
+        </CuiCard>
+
+        <CuiCard variant="outline">
+          <CuiCardHeader title="No library? Hand-write a resolver" />
+          <CuiCardBody>
+            <pre class="cui-pre"><code class="cui-code">function resolver(values) {
+  const errors = {};
+  if (!values.email) errors.email = "Email is required";
+  if (!values.role) errors.role = "Pick a role";
+  return errors; // {} means valid
+}</code></pre>
+          </CuiCardBody>
+        </CuiCard>
+      </CuiStack>
+    </div>
+  </CuiStack>
+</template>

--- a/apps/docs/src/pages/FormPage.vue
+++ b/apps/docs/src/pages/FormPage.vue
@@ -46,6 +46,49 @@ function onSubmit(values: FormValues) {
 function onInvalid(errors: FormErrors) {
   result.value = `❌ Invalid: ${Object.keys(errors).length} field(s) need attention`;
 }
+
+// --- AJAX submit example -----------------------------------------------------
+// Template ref to the form so we can map server errors back onto the fields.
+const ajaxForm = ref<{ setErrors: (e: FormErrors) => void; reset: () => void } | null>(null);
+const ajaxValues = ref<FormValues>({ email: "", username: "" });
+const ajaxResult = ref("(submit to POST — try taken@example.com)");
+
+function ajaxResolver(values: FormValues): FormErrors {
+  const errors: FormErrors = {};
+  if (!values.email) errors.email = "Email is required";
+  if (!values.username) errors.username = "Username is required";
+  return errors;
+}
+
+// Stands in for a real `fetch` — returns 201, or a 422 with field errors when
+// the email is "taken", so the demo works offline.
+function fakePost(values: FormValues): Promise<{ ok: boolean; status: number; errors?: FormErrors }> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      if (values.email === "taken@example.com") {
+        resolve({ ok: false, status: 422, errors: { email: "That email is already registered" } });
+      } else {
+        resolve({ ok: true, status: 201 });
+      }
+    }, 900);
+  });
+}
+
+async function onAjaxSubmit(values: FormValues) {
+  ajaxResult.value = "⏳ POSTing…";
+  try {
+    const res = await fakePost(values);
+    if (res.ok) {
+      ajaxResult.value = `✅ Created (HTTP ${res.status})`;
+      ajaxForm.value?.reset();
+    } else if (res.status === 422 && res.errors) {
+      ajaxForm.value?.setErrors(res.errors);
+      ajaxResult.value = "❌ Server rejected the form (422) — see the field errors";
+    }
+  } catch {
+    ajaxResult.value = "❌ Network error — please try again";
+  }
+}
 </script>
 
 <template>
@@ -97,8 +140,10 @@ function onInvalid(errors: FormErrors) {
       <p class="mt-3 text-sm" style="color: var(--cui-text-secondary);">
         Exposes via <code class="cui-code">ref</code>: <code class="cui-code">validate()</code>,
         <code class="cui-code">reset(values?)</code>, <code class="cui-code">submit()</code>,
-        plus reactive <code class="cui-code">values</code> and <code class="cui-code">errors</code>.
-        The default slot also receives <code class="cui-code">{ values, errors, submitted }</code>.
+        <code class="cui-code">setErrors(errors)</code> (for server-side errors),
+        plus reactive <code class="cui-code">values</code>, <code class="cui-code">errors</code>, and
+        <code class="cui-code">submitting</code>. The default slot also receives
+        <code class="cui-code">{ values, errors, submitted, submitting }</code>.
       </p>
     </div>
 
@@ -180,6 +225,75 @@ function onInvalid(errors: FormErrors) {
               <CuiAlert :color="result.startsWith('✅') ? 'success' : result.startsWith('❌') ? 'error' : 'info'" variant="subtle" :title="result" />
             </CuiStack>
           </CuiForm>
+        </Example>
+
+        <Example title="AJAX submit (loading state + server errors)" :code="`<script setup>
+const form = ref()
+const values = ref({ email: '', username: '' })
+
+async function onSubmit(values) {
+  const res = await fetch('/api/users', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(values),
+  })
+  if (res.ok) {
+    form.value.reset()           // success — toast / navigate / reset
+    return
+  }
+  if (res.status === 422) {
+    // map server-side field errors back onto the form
+    const { errors } = await res.json()   // { email: 'Already registered' }
+    form.value.setErrors(errors)
+  }
+}
+&lt;/script>
+
+<template>
+  <CuiForm ref=&quot;form&quot; :resolver=&quot;resolver&quot; v-model=&quot;values&quot;
+           @submit=&quot;onSubmit&quot; v-slot=&quot;{ submitting }&quot;>
+    <CuiFormField name=&quot;email&quot; label=&quot;Email&quot; required v-slot=&quot;f&quot;>
+      <CuiInput v-bind=&quot;f&quot; type=&quot;email&quot; />
+    </CuiFormField>
+    <CuiFormField name=&quot;username&quot; label=&quot;Username&quot; required v-slot=&quot;f&quot;>
+      <CuiInput v-bind=&quot;f&quot; />
+    </CuiFormField>
+    <!-- submitting comes from the form — no manual loading flag -->
+    <CuiButton type=&quot;submit&quot; :disabled=&quot;submitting&quot;>
+      {{ submitting ? 'Saving…' : 'Create account' }}
+    </CuiButton>
+  </CuiForm>
+</template>`">
+          <CuiForm
+            ref="ajaxForm"
+            :resolver="ajaxResolver"
+            v-model="ajaxValues"
+            @submit="onAjaxSubmit"
+            v-slot="{ submitting }"
+          >
+            <CuiStack spacing="4">
+              <CuiFormField name="email" label="Email" required help-text="Use taken@example.com to see a 422 mapped back" v-slot="f">
+                <CuiInput v-bind="f" type="email" placeholder="you@example.com" />
+              </CuiFormField>
+
+              <CuiFormField name="username" label="Username" required v-slot="f">
+                <CuiInput v-bind="f" placeholder="yourhandle" />
+              </CuiFormField>
+
+              <div>
+                <CuiButton type="submit" variant="solid" color="primary" :disabled="submitting">
+                  {{ submitting ? "Saving…" : "Create account" }}
+                </CuiButton>
+              </div>
+
+              <CuiAlert :color="ajaxResult.startsWith('✅') ? 'success' : ajaxResult.startsWith('❌') ? 'error' : 'info'" variant="subtle" :title="ajaxResult" />
+            </CuiStack>
+          </CuiForm>
+          <p class="mt-2 text-sm" style="color: var(--cui-text-secondary);">
+            The live demo simulates the request (≈900ms) — the submit button is driven by the
+            form's <code class="cui-code">submitting</code> state, and a “taken” email returns a
+            422 that maps onto the Email field via <code class="cui-code">setErrors</code>.
+          </p>
         </Example>
 
         <!-- Validation recipes -->

--- a/apps/docs/src/router/index.ts
+++ b/apps/docs/src/router/index.ts
@@ -149,6 +149,11 @@ const router = createRouter({
       component: () => import('../pages/FieldsetPage.vue'),
     },
     {
+      path: '/components/form',
+      name: 'form',
+      component: () => import('../pages/FormPage.vue'),
+    },
+    {
       path: '/components/form-field',
       name: 'form-field',
       component: () => import('../pages/FormFieldPage.vue'),

--- a/packages/clean-ui/src/components/CuiForm.vue
+++ b/packages/clean-ui/src/components/CuiForm.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import { ref, computed, provide, watch } from "vue";
+import type { HideableProps, DisableableProps } from "../types/common";
+import {
+  FormContextKey,
+  type FormValues,
+  type FormErrors,
+  type FormResolver,
+  type FormValidateOn,
+} from "./form-context";
+
+export interface CuiFormProps extends HideableProps, DisableableProps {
+  /** Form values (v-model). Use to seed initial values and stay in sync. */
+  modelValue?: FormValues;
+  /** Library-agnostic validation: (values) => errors map (sync or async). */
+  resolver?: FormResolver;
+  /**
+   * When eager validation kicks in. `"submit"` (default) validates on submit,
+   * then revalidates a field whenever it changes. `"change"` validates from the
+   * very first keystroke.
+   */
+  validateOn?: FormValidateOn;
+  /** Make every field readonly. */
+  readonly?: boolean;
+}
+
+const props = withDefaults(defineProps<CuiFormProps>(), {
+  validateOn: "submit",
+  disabled: false,
+  readonly: false,
+  hidden: false,
+});
+
+const emit = defineEmits<{
+  "update:modelValue": [values: FormValues];
+  /** Fired after a submit that passed validation. */
+  submit: [values: FormValues];
+  /** Fired after a submit that failed validation. */
+  "submit-invalid": [errors: FormErrors];
+}>();
+
+// --- Value bag ----------------------------------------------------------------
+// Deep-reactive internal copy seeded from modelValue. We keep our own ref so the
+// form works uncontrolled (no v-model) too; when controlled we sync both ways.
+const values = ref<FormValues>({ ...(props.modelValue ?? {}) });
+const errors = ref<FormErrors>({});
+const submitted = ref(false);
+const registered = new Set<string>();
+
+// External modelValue changes flow in (e.g. parent reset/prefill).
+watch(
+  () => props.modelValue,
+  (next) => {
+    if (next && next !== values.value) values.value = { ...next };
+  },
+  { deep: true },
+);
+
+// --- Dot-path get/set (supports nested schemas like "address.city") ----------
+function getPath(obj: FormValues, path: string): unknown {
+  return path.split(".").reduce<unknown>((acc, key) => {
+    if (acc && typeof acc === "object") return (acc as Record<string, unknown>)[key];
+    return undefined;
+  }, obj);
+}
+
+function setPath(obj: FormValues, path: string, value: unknown): void {
+  const keys = path.split(".");
+  let cursor = obj as Record<string, unknown>;
+  for (let i = 0; i < keys.length - 1; i++) {
+    const key = keys[i];
+    if (typeof cursor[key] !== "object" || cursor[key] === null) cursor[key] = {};
+    cursor = cursor[key] as Record<string, unknown>;
+  }
+  cursor[keys[keys.length - 1]] = value;
+}
+
+// --- Validation ---------------------------------------------------------------
+async function runResolver(): Promise<FormErrors> {
+  if (!props.resolver) return {};
+  return (await props.resolver(values.value)) ?? {};
+}
+
+/** Validate the whole form; sets `errors` and returns the errors map. */
+async function validate(): Promise<FormErrors> {
+  const result = await runResolver();
+  errors.value = result;
+  return result;
+}
+
+/** Validate, but only update the error for a single field (used on change). */
+async function validateField(name: string): Promise<void> {
+  const result = await runResolver();
+  const next = { ...errors.value };
+  if (result[name]) next[name] = result[name];
+  else delete next[name];
+  errors.value = next;
+}
+
+function getValue(name: string): unknown {
+  return getPath(values.value, name);
+}
+
+function setValue(name: string, value: unknown): void {
+  setPath(values.value, name, value);
+  emit("update:modelValue", values.value);
+  if (props.validateOn === "change" || submitted.value) void validateField(name);
+}
+
+function registerField(name: string): void {
+  registered.add(name);
+}
+
+function unregisterField(name: string): void {
+  registered.delete(name);
+}
+
+// --- Submit / reset (also exposed) -------------------------------------------
+async function submit(): Promise<void> {
+  submitted.value = true;
+  const result = await validate();
+  if (Object.keys(result).length === 0) emit("submit", values.value);
+  else emit("submit-invalid", result);
+}
+
+function reset(next?: FormValues): void {
+  values.value = { ...(next ?? props.modelValue ?? {}) };
+  errors.value = {};
+  submitted.value = false;
+  emit("update:modelValue", values.value);
+}
+
+provide(FormContextKey, {
+  values,
+  errors,
+  submitted,
+  disabled: computed(() => props.disabled),
+  readonly: computed(() => props.readonly),
+  getValue,
+  setValue,
+  validateField,
+  registerField,
+  unregisterField,
+});
+
+defineExpose({ validate, reset, submit, values, errors });
+</script>
+
+<template>
+  <form v-show="!hidden" class="cui-form" novalidate @submit.prevent="submit">
+    <slot :values="values" :errors="errors" :submitted="submitted" />
+  </form>
+</template>

--- a/packages/clean-ui/src/components/CuiForm.vue
+++ b/packages/clean-ui/src/components/CuiForm.vue
@@ -162,6 +162,16 @@ function reset(next?: FormValues): void {
   emit("update:modelValue", { ...values.value });
 }
 
+/**
+ * Imperatively set the error map — typically to surface server-side validation
+ * (e.g. a 422 response) on the matching fields. Bumps the validation token so an
+ * in-flight resolver run can't overwrite what the server just told us.
+ */
+function setErrors(next: FormErrors): void {
+  validateSeq++;
+  errors.value = { ...next };
+}
+
 provide(FormContextKey, {
   values,
   errors,
@@ -174,7 +184,7 @@ provide(FormContextKey, {
   unregisterField,
 });
 
-defineExpose({ validate, reset, submit, values, errors, submitting });
+defineExpose({ validate, reset, submit, setErrors, values, errors, submitting });
 </script>
 
 <template>

--- a/packages/clean-ui/src/components/CuiForm.vue
+++ b/packages/clean-ui/src/components/CuiForm.vue
@@ -40,18 +40,32 @@ const emit = defineEmits<{
 }>();
 
 // --- Value bag ----------------------------------------------------------------
-// Deep-reactive internal copy seeded from modelValue. We keep our own ref so the
-// form works uncontrolled (no v-model) too; when controlled we sync both ways.
-const values = ref<FormValues>({ ...(props.modelValue ?? {}) });
+// Deep-clone the seed so nested objects aren't shared with the parent's object
+// (in-place writes to a dot-path must not mutate the caller's state).
+function seed(source?: FormValues): FormValues {
+  if (!source) return {};
+  try {
+    return structuredClone(source);
+  } catch {
+    return { ...source };
+  }
+}
+
+// Internal source of truth. We keep our own ref so the form works uncontrolled
+// (no v-model) too; when controlled we sync both ways.
+const values = ref<FormValues>(seed(props.modelValue));
 const errors = ref<FormErrors>({});
 const submitted = ref(false);
-const registered = new Set<string>();
+const submitting = ref(false);
+
+// Monotonic token so a slower async validation can't clobber a newer one.
+let validateSeq = 0;
 
 // External modelValue changes flow in (e.g. parent reset/prefill).
 watch(
   () => props.modelValue,
   (next) => {
-    if (next && next !== values.value) values.value = { ...next };
+    if (next && next !== values.value) values.value = seed(next);
   },
   { deep: true },
 );
@@ -83,14 +97,22 @@ async function runResolver(): Promise<FormErrors> {
 
 /** Validate the whole form; sets `errors` and returns the errors map. */
 async function validate(): Promise<FormErrors> {
+  const seq = ++validateSeq;
   const result = await runResolver();
-  errors.value = result;
+  // Only publish to the UI if a newer validation hasn't started meanwhile.
+  if (seq === validateSeq) errors.value = result;
   return result;
 }
 
-/** Validate, but only update the error for a single field (used on change). */
+/**
+ * Re-run validation but update only the changed field's error, leaving untouched
+ * fields pristine. Resolvers validate the whole object, so in `"change"` mode this
+ * expects a cheap/sync resolver (one run per keystroke).
+ */
 async function validateField(name: string): Promise<void> {
+  const seq = ++validateSeq;
   const result = await runResolver();
+  if (seq !== validateSeq) return; // superseded by a newer validation
   const next = { ...errors.value };
   if (result[name]) next[name] = result[name];
   else delete next[name];
@@ -103,31 +125,41 @@ function getValue(name: string): unknown {
 
 function setValue(name: string, value: unknown): void {
   setPath(values.value, name, value);
-  emit("update:modelValue", values.value);
+  // Emit a fresh object so parents using a non-deep watcher still react.
+  emit("update:modelValue", { ...values.value });
   if (props.validateOn === "change" || submitted.value) void validateField(name);
 }
 
-function registerField(name: string): void {
-  registered.add(name);
-}
-
+/**
+ * Drop a field's error when it unmounts (e.g. a conditionally-shown field) so
+ * stale errors for fields the user can no longer fix don't linger in the map.
+ */
 function unregisterField(name: string): void {
-  registered.delete(name);
+  if (!(name in errors.value)) return;
+  const next = { ...errors.value };
+  delete next[name];
+  errors.value = next;
 }
 
 // --- Submit / reset (also exposed) -------------------------------------------
 async function submit(): Promise<void> {
+  if (submitting.value) return; // guard against concurrent double-submit
+  submitting.value = true;
   submitted.value = true;
-  const result = await validate();
-  if (Object.keys(result).length === 0) emit("submit", values.value);
-  else emit("submit-invalid", result);
+  try {
+    const result = await validate();
+    if (Object.keys(result).length === 0) emit("submit", values.value);
+    else emit("submit-invalid", result);
+  } finally {
+    submitting.value = false;
+  }
 }
 
 function reset(next?: FormValues): void {
-  values.value = { ...(next ?? props.modelValue ?? {}) };
+  values.value = seed(next ?? props.modelValue);
   errors.value = {};
   submitted.value = false;
-  emit("update:modelValue", values.value);
+  emit("update:modelValue", { ...values.value });
 }
 
 provide(FormContextKey, {
@@ -139,15 +171,14 @@ provide(FormContextKey, {
   getValue,
   setValue,
   validateField,
-  registerField,
   unregisterField,
 });
 
-defineExpose({ validate, reset, submit, values, errors });
+defineExpose({ validate, reset, submit, values, errors, submitting });
 </script>
 
 <template>
   <form v-show="!hidden" class="cui-form" novalidate @submit.prevent="submit">
-    <slot :values="values" :errors="errors" :submitted="submitted" />
+    <slot :values="values" :errors="errors" :submitted="submitted" :submitting="submitting" />
   </form>
 </template>

--- a/packages/clean-ui/src/components/CuiFormField.vue
+++ b/packages/clean-ui/src/components/CuiFormField.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, inject, onMounted, onBeforeUnmount } from "vue";
+import { computed, inject, onBeforeUnmount } from "vue";
 import type { HideableProps, DisableableProps } from "../types/common";
 import { FormContextKey } from "./form-context";
 
@@ -67,13 +67,13 @@ const slotBindings = computed(() => {
   if (formBound.value) {
     base.modelValue = form!.getValue(props.name!);
     base["onUpdate:modelValue"] = (value: unknown) => form!.setValue(props.name!, value);
+    base.readonly = form!.readonly.value;
   }
   return base;
 });
 
-onMounted(() => {
-  if (formBound.value) form!.registerField(props.name!);
-});
+// Clear this field's error from the form when it unmounts (e.g. conditionally
+// shown fields) so stale errors don't linger in the aggregated map.
 onBeforeUnmount(() => {
   if (props.name && form) form.unregisterField(props.name);
 });

--- a/packages/clean-ui/src/components/CuiFormField.vue
+++ b/packages/clean-ui/src/components/CuiFormField.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, inject, onMounted, onBeforeUnmount } from "vue";
 import type { HideableProps, DisableableProps } from "../types/common";
+import { FormContextKey } from "./form-context";
 
 export type LabelPosition = "top" | "left";
 
@@ -11,15 +12,21 @@ export interface CuiFormFieldProps extends HideableProps, DisableableProps {
   labelPosition?: LabelPosition;
   /** HTML for attribute — ties label to a control by id */
   for?: string;
+  /**
+   * Field name. When set AND nested in a `CuiForm`, the field binds its value
+   * and error to the form automatically (see the scoped-slot bindings). Omit it
+   * to use the field standalone with manual `error` / `errorMessage` props.
+   */
+  name?: string;
   /** Mark field as required */
   required?: boolean;
   /** Custom required indicator text (replaces asterisk) */
   requiredText?: string;
   /** Help text below the control */
   helpText?: string;
-  /** Show error state (left accent bar) */
+  /** Show error state (standalone mode; ignored when form-bound) */
   error?: boolean;
-  /** Error message below the control (replaces help text when shown) */
+  /** Error message below the control (standalone mode; ignored when form-bound) */
   errorMessage?: string;
 }
 
@@ -31,10 +38,45 @@ const props = withDefaults(defineProps<CuiFormFieldProps>(), {
   hidden: false,
 });
 
-const showError = computed(() => props.error && props.errorMessage);
+// Optional form context — null when used standalone (no hard dependency).
+const form = inject(FormContextKey, null);
+const formBound = computed(() => !!props.name && !!form);
+
+// Resolved error/message: from the form when bound, else from props.
+const resolvedError = computed(() =>
+  formBound.value ? !!form!.errors.value[props.name!] : !!props.error,
+);
+const resolvedMessage = computed(() =>
+  formBound.value ? form!.errors.value[props.name!] : props.errorMessage,
+);
+const showError = computed(() => resolvedError.value && resolvedMessage.value);
+
+const isDisabled = computed(() => props.disabled || (form?.disabled.value ?? false));
 
 // Auto-generate a stable id once (not a computed — Math.random() must not re-run on re-render)
 const fieldId = props.for ?? `cui-field-${Math.random().toString(36).slice(2, 8)}`;
+
+// Bindings handed to the default slot. `v-bind="f"` on a field component wires
+// v-model + error in one shot. Standalone mode omits the model bindings.
+const slotBindings = computed(() => {
+  const base: Record<string, unknown> = {
+    id: fieldId,
+    error: resolvedError.value,
+    disabled: isDisabled.value,
+  };
+  if (formBound.value) {
+    base.modelValue = form!.getValue(props.name!);
+    base["onUpdate:modelValue"] = (value: unknown) => form!.setValue(props.name!, value);
+  }
+  return base;
+});
+
+onMounted(() => {
+  if (formBound.value) form!.registerField(props.name!);
+});
+onBeforeUnmount(() => {
+  if (props.name && form) form.unregisterField(props.name);
+});
 </script>
 
 <template>
@@ -43,7 +85,7 @@ const fieldId = props.for ?? `cui-field-${Math.random().toString(36).slice(2, 8)
     class="cui-form-field"
     :class="[
       `cui-form-field--${labelPosition}`,
-      { 'cui-form-field--error': error },
+      { 'cui-form-field--error': resolvedError },
     ]"
   >
     <!-- Label -->
@@ -61,12 +103,12 @@ const fieldId = props.for ?? `cui-field-${Math.random().toString(36).slice(2, 8)
     <div class="cui-form-field__body">
       <!-- Control slot -->
       <div class="cui-form-field__control">
-        <slot :id="fieldId" :error="error" :disabled="disabled" />
+        <slot v-bind="slotBindings" />
       </div>
 
       <!-- Footer: help text or error message -->
       <div v-if="showError" class="cui-form-field__error">
-        {{ errorMessage }}
+        {{ resolvedMessage }}
       </div>
       <div v-else-if="helpText" class="cui-form-field__help">
         {{ helpText }}

--- a/packages/clean-ui/src/components/form-context.ts
+++ b/packages/clean-ui/src/components/form-context.ts
@@ -38,9 +38,7 @@ export interface FormContext {
   setValue: (name: string, value: unknown) => void;
   /** Re-run validation and update just this field's error. */
   validateField: (name: string) => void;
-  /** Track a mounted field (for aggregation + pruning stale errors). */
-  registerField: (name: string) => void;
-  /** Stop tracking a field on unmount. */
+  /** Drop a field's error when it unmounts, so stale errors don't linger. */
   unregisterField: (name: string) => void;
 }
 

--- a/packages/clean-ui/src/components/form-context.ts
+++ b/packages/clean-ui/src/components/form-context.ts
@@ -1,0 +1,47 @@
+import type { InjectionKey, Ref } from "vue";
+
+/** A form's value bag. Keys are field names (dot-paths allowed, e.g. "address.city"). */
+export type FormValues = Record<string, unknown>;
+
+/** Validation errors keyed by field name. An empty object means "valid". */
+export type FormErrors = Record<string, string>;
+
+/**
+ * A resolver turns the current values into an errors map. It is library-agnostic:
+ * adapt zod/valibot/yup/custom logic to this signature. Return `{}` when valid.
+ * May be sync or async.
+ */
+export type FormResolver = (values: FormValues) => FormErrors | Promise<FormErrors>;
+
+/** When validation runs. Always validates on submit; this controls eager behaviour. */
+export type FormValidateOn = "submit" | "change";
+
+/**
+ * Shared context a `CuiForm` provides to descendant `CuiFormField`s.
+ * Field components never inject this directly — they stay standalone; only the
+ * form-aware `CuiFormField` wrapper wires a field to the form.
+ */
+export interface FormContext {
+  /** Reactive value bag. */
+  values: Ref<FormValues>;
+  /** Reactive errors keyed by field name. */
+  errors: Ref<FormErrors>;
+  /** Whether the form has been submitted at least once (drives revalidation). */
+  submitted: Ref<boolean>;
+  /** Form-wide disabled flag (fields merge this with their own). */
+  disabled: Ref<boolean>;
+  /** Form-wide readonly flag. */
+  readonly: Ref<boolean>;
+  /** Read a field's value (supports dot-paths). */
+  getValue: (name: string) => unknown;
+  /** Write a field's value (supports dot-paths); revalidates per `validateOn`. */
+  setValue: (name: string, value: unknown) => void;
+  /** Re-run validation and update just this field's error. */
+  validateField: (name: string) => void;
+  /** Track a mounted field (for aggregation + pruning stale errors). */
+  registerField: (name: string) => void;
+  /** Stop tracking a field on unmount. */
+  unregisterField: (name: string) => void;
+}
+
+export const FormContextKey: InjectionKey<FormContext> = Symbol("cui-form");

--- a/packages/clean-ui/src/index.ts
+++ b/packages/clean-ui/src/index.ts
@@ -22,6 +22,7 @@ import CuiMaskedInput from "./components/CuiMaskedInput.vue";
 import CuiTextarea from "./components/CuiTextarea.vue";
 import CuiSelect from "./components/CuiSelect.vue";
 import CuiFormField from "./components/CuiFormField.vue";
+import CuiForm from "./components/CuiForm.vue";
 import CuiFieldset from "./components/CuiFieldset.vue";
 import CuiBadge from "./components/CuiBadge.vue";
 import CuiAlert from "./components/CuiAlert.vue";
@@ -98,7 +99,7 @@ import CuiRating from "./components/CuiRating.vue";
 import "./styles/main.css";
 
 // Component exports
-export { CuiButton, CuiButtonGroup, CuiGrid, CuiGridItem, CuiFlex, CuiFlexItem, CuiStack, CuiContainer, CuiSpacer, CuiRadio, CuiRadioGroup, CuiCheckbox, CuiCheckboxGroup, CuiToggle, CuiToggleGroup, CuiInput, CuiMaskedInput, CuiTextarea, CuiSelect, CuiFormField, CuiFieldset, CuiBadge, CuiAlert, CuiTooltip, CuiToast, CuiToastProvider, CuiIcon, CuiBackdrop, CuiModal, CuiModalHeader, CuiModalBody, CuiModalFooter, CuiTabs, CuiTab, CuiDropdown, CuiDropdownTrigger, CuiDropdownMenu, CuiDropdownItem, CuiDropdownCheckItem, CuiDropdownRadioGroup, CuiDropdownRadioItem, CuiDropdownDivider, CuiDropdownHeader, CuiDropdownSub, CuiProgress, CuiPagination, CuiBreadcrumb, CuiBreadcrumbItem, CuiCard, CuiCardHeader, CuiCardBody, CuiCardFooter, CuiCardMedia, CuiAccordion, CuiAccordionItem, CuiSlideover, CuiSkeleton, CuiPopover, CuiContextMenu, CuiEmptyState, CuiTable, CuiTableHead, CuiTableBody, CuiTableFoot, CuiTableRow, CuiTableCell, CuiDataGrid, CuiAvatar, CuiAvatarGroup, CuiStepper, CuiInputStepper, CuiSlider, CuiSpinner, CuiBanner, CuiDivider, CuiCopyButton, CuiResizablePanels, CuiConfirmDialog, CuiTimeline, CuiTimelineItem, CuiKbd, CuiColorPicker, CuiDatePicker, CuiDateRangePicker, CuiCombobox, CuiTransferList, CuiTimePicker, CuiTagInput, CuiFileUpload, CuiTreeView, CuiCodeBlock, CuiRating };
+export { CuiButton, CuiButtonGroup, CuiGrid, CuiGridItem, CuiFlex, CuiFlexItem, CuiStack, CuiContainer, CuiSpacer, CuiRadio, CuiRadioGroup, CuiCheckbox, CuiCheckboxGroup, CuiToggle, CuiToggleGroup, CuiInput, CuiMaskedInput, CuiTextarea, CuiSelect, CuiFormField, CuiForm, CuiFieldset, CuiBadge, CuiAlert, CuiTooltip, CuiToast, CuiToastProvider, CuiIcon, CuiBackdrop, CuiModal, CuiModalHeader, CuiModalBody, CuiModalFooter, CuiTabs, CuiTab, CuiDropdown, CuiDropdownTrigger, CuiDropdownMenu, CuiDropdownItem, CuiDropdownCheckItem, CuiDropdownRadioGroup, CuiDropdownRadioItem, CuiDropdownDivider, CuiDropdownHeader, CuiDropdownSub, CuiProgress, CuiPagination, CuiBreadcrumb, CuiBreadcrumbItem, CuiCard, CuiCardHeader, CuiCardBody, CuiCardFooter, CuiCardMedia, CuiAccordion, CuiAccordionItem, CuiSlideover, CuiSkeleton, CuiPopover, CuiContextMenu, CuiEmptyState, CuiTable, CuiTableHead, CuiTableBody, CuiTableFoot, CuiTableRow, CuiTableCell, CuiDataGrid, CuiAvatar, CuiAvatarGroup, CuiStepper, CuiInputStepper, CuiSlider, CuiSpinner, CuiBanner, CuiDivider, CuiCopyButton, CuiResizablePanels, CuiConfirmDialog, CuiTimeline, CuiTimelineItem, CuiKbd, CuiColorPicker, CuiDatePicker, CuiDateRangePicker, CuiCombobox, CuiTransferList, CuiTimePicker, CuiTagInput, CuiFileUpload, CuiTreeView, CuiCodeBlock, CuiRating };
 
 // Type exports
 export type {
@@ -134,6 +135,16 @@ export type { CuiMaskedInputProps, MaskToken } from "./components/CuiMaskedInput
 export type { CuiTextareaProps } from "./components/CuiTextarea.vue";
 export type { CuiSelectProps, SelectOption } from "./components/CuiSelect.vue";
 export type { CuiFormFieldProps, LabelPosition } from "./components/CuiFormField.vue";
+export type { CuiFormProps } from "./components/CuiForm.vue";
+export { FormContextKey } from "./components/form-context";
+export type {
+  FormContext,
+  FormValues,
+  FormErrors,
+  FormResolver,
+  FormValidateOn,
+} from "./components/form-context";
+export { zodResolver, valibotResolver } from "./utils/resolvers";
 export type { CuiFieldsetProps, FieldsetVariant } from "./components/CuiFieldset.vue";
 export type { CuiBadgeProps, BadgeVariant, BadgeAnimation } from "./components/CuiBadge.vue";
 export type { CuiAlertProps, AlertVariant, AlertEntrance, AlertAnimation } from "./components/CuiAlert.vue";
@@ -291,6 +302,7 @@ export function createCleanUI(_options: CleanUIOptions = {}) {
       app.component("CuiTextarea", CuiTextarea);
       app.component("CuiSelect", CuiSelect);
       app.component("CuiFormField", CuiFormField);
+      app.component("CuiForm", CuiForm);
       app.component("CuiFieldset", CuiFieldset);
       app.component("CuiBadge", CuiBadge);
       app.component("CuiAlert", CuiAlert);

--- a/packages/clean-ui/src/utils/resolvers.ts
+++ b/packages/clean-ui/src/utils/resolvers.ts
@@ -1,0 +1,68 @@
+import type { FormResolver, FormErrors, FormValues } from "../components/form-context";
+
+// Structural shapes for the validation libraries we adapt — declared locally so
+// the library takes NO runtime dependency on zod/valibot. Consumers pass their
+// own schema instance; we only touch its `safeParse`.
+
+/** Minimal shape of a zod schema's `safeParse` result. */
+interface ZodLikeSchema {
+  safeParse: (value: unknown) => {
+    success: boolean;
+    error?: { issues: Array<{ path: Array<string | number>; message: string }> };
+  };
+}
+
+/** Minimal shape of valibot's `safeParse(schema, value)` return. */
+interface ValibotSafeParseResult {
+  success: boolean;
+  issues?: Array<{ message: string; path?: Array<{ key: string | number }> }>;
+}
+
+/**
+ * Adapt a zod schema (or anything with a compatible `safeParse`) into a
+ * `CuiForm` resolver. The first issue per field wins.
+ *
+ * ```ts
+ * import { z } from "zod";
+ * const schema = z.object({ email: z.string().email() });
+ * const resolver = zodResolver(schema);
+ * // <CuiForm :resolver="resolver" />
+ * ```
+ */
+export function zodResolver(schema: ZodLikeSchema): FormResolver {
+  return (values: FormValues): FormErrors => {
+    const result = schema.safeParse(values);
+    if (result.success || !result.error) return {};
+    const errors: FormErrors = {};
+    for (const issue of result.error.issues) {
+      const path = issue.path.join(".");
+      if (path && !(path in errors)) errors[path] = issue.message;
+    }
+    return errors;
+  };
+}
+
+/**
+ * Adapt valibot's `safeParse` into a `CuiForm` resolver. Pass a thunk that runs
+ * `safeParse(schema, values)` so this stays dependency-free.
+ *
+ * ```ts
+ * import * as v from "valibot";
+ * const schema = v.object({ email: v.pipe(v.string(), v.email()) });
+ * const resolver = valibotResolver((values) => v.safeParse(schema, values));
+ * ```
+ */
+export function valibotResolver(
+  run: (values: FormValues) => ValibotSafeParseResult,
+): FormResolver {
+  return (values: FormValues): FormErrors => {
+    const result = run(values);
+    if (result.success || !result.issues) return {};
+    const errors: FormErrors = {};
+    for (const issue of result.issues) {
+      const path = (issue.path ?? []).map((p) => p.key).join(".");
+      if (path && !(path in errors)) errors[path] = issue.message;
+    }
+    return errors;
+  };
+}


### PR DESCRIPTION
Closes #9.

## What
Adds a form-level layer over the existing field components — value tracking, error aggregation, submit handling, and a library-agnostic validation hook — without coupling any field component to the form.

## API at a glance
```vue
<CuiForm :resolver="resolver" v-model="values" @submit="save">
  <CuiFormField name="email" label="Email" required v-slot="f">
    <CuiInput v-bind="f" type="email" />
  </CuiFormField>

  <CuiFormField name="role" label="Role" required v-slot="f">
    <CuiSelect v-bind="f" :options="roleOptions" />
  </CuiFormField>

  <CuiButton type="submit">Save</CuiButton>
</CuiForm>
```
`f = { id, modelValue, "onUpdate:modelValue", error, disabled }` — `v-bind="f"` wires v-model + error in one shot. `CuiFormField` renders the label + error message; the field shows the red border.

## Design decisions
- **Binding via `CuiFormField` `name` prop** (not a `name` on every field) — keeps field components 100% standalone, which issue #9 requires. The `inject` defaults to `null`, so existing standalone usage is unchanged.
- **Library-agnostic `:resolver`** = `(values) => FormErrors | Promise<FormErrors>`. Ships `zodResolver` **and** `valibotResolver` adapters with **zero runtime dependency** on either library (structural typing). Hand-written resolvers work too.
- `validateOn: "submit"` (default) validates on submit, then live-revalidates each field as it's corrected; `"change"` validates eagerly.

## Acceptance criteria
- [x] `CuiForm` context with submit + error aggregation
- [x] Documented validation-library integration recipe (zod + valibot + hand-rolled, on the new docs page)
- [x] Field components unaffected when used standalone

## Files
- `packages/clean-ui/src/components/CuiForm.vue`, `form-context.ts` — new
- `packages/clean-ui/src/utils/resolvers.ts` — new (`zodResolver`, `valibotResolver`)
- `packages/clean-ui/src/components/CuiFormField.vue` — optional form binding via `name`
- `packages/clean-ui/src/index.ts` — exports + plugin registration
- `apps/docs/` — new Form page, route, nav entry

## Verification
- `pnpm --filter @itguy614/clean-ui build` passes (vite + `vue-tsc` declaration emit)
- docs `vue-tsc --noEmit` — 0 errors
- dev-server smoke test: Form page transforms and serves cleanly

⚠️ Compile/type/load verified; interactive submit+validation reasoned through but not yet click-tested in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)