### PR TITLE
feat(a11y): live-region semantics for Toast/Alert/Banner

### DIFF
--- a/apps/docs/src/pages/AlertPage.vue
+++ b/apps/docs/src/pages/AlertPage.vue
@@ -37,6 +37,7 @@ const showPulse = ref(true);
           { name: 'autoDismiss', type: 'number', default: '-', description: 'Auto-dismiss after N milliseconds' },
           { name: 'entrance', type: 'fade | slide-down | slide-left | none', default: 'fade', description: 'Entrance animation on mount' },
           { name: 'animation', type: 'pulse | glow | shake | none', default: 'none', description: 'Persistent attention animation' },
+          { name: 'live', type: 'off | polite | assertive', default: 'from color', description: 'Screen-reader live region. error -> assertive (role=alert), else polite (role=status). off to silence.' },
           { name: 'hidden', type: 'boolean', default: 'false', description: 'Hide the component' },
         ]"
       />

--- a/apps/docs/src/pages/BannerPage.vue
+++ b/apps/docs/src/pages/BannerPage.vue
@@ -40,6 +40,7 @@ function resetAll() {
           { name: 'dismissible', type: 'boolean', default: 'true', description: 'Show dismiss button' },
           { name: 'noIcon', type: 'boolean', default: 'false', description: 'Hide default role icon' },
           { name: 'storageKey', type: 'string', default: '—', description: 'Persist dismissal to localStorage under this key' },
+          { name: 'live', type: 'off | polite | assertive', default: 'from color', description: 'Screen-reader live region. error -> assertive (role=alert), else polite (role=status). off to silence promotional banners.' },
           { name: 'hidden', type: 'boolean', default: 'false', description: 'Hide the component' },
         ]"
       />

--- a/apps/docs/src/pages/ToastPage.vue
+++ b/apps/docs/src/pages/ToastPage.vue
@@ -133,6 +133,7 @@ function floodTest() {
           { name: 'animation', type: 'pulse | glow | shake | none', default: 'none', description: 'Persistent attention animation' },
           { name: 'icon', type: 'string', default: '-', description: 'Custom icon (emoji/text)' },
           { name: 'noIcon', type: 'boolean', default: 'false', description: 'Hide the auto-icon' },
+          { name: 'live', type: 'off | polite | assertive', default: 'from color', description: 'Screen-reader live region. error -> assertive (role=alert), else polite (role=status).' },
           { name: 'hidden', type: 'boolean', default: 'false', description: 'Hide the component' },
         ]"
       />

--- a/packages/clean-ui/src/components/CuiAlert.vue
+++ b/packages/clean-ui/src/components/CuiAlert.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, computed } from "vue";
-import type { HideableProps, ColorableProps, CuiRounded } from "../types/common";
+import type { HideableProps, ColorableProps, CuiRounded, LiveRegionProps } from "../types/common";
 import CuiIcon from "./CuiIcon.vue";
 import { COLOR_ICON_MAP } from "../utils/colorIconMap";
-import { resolveLiveRegion, type LiveRegionMode } from "../utils/liveRegion";
+import { resolveLiveRegion } from "../utils/liveRegion";
 
 const radiusMap: Record<CuiRounded, string> = {
   none: "0",
@@ -17,7 +17,7 @@ export type AlertVariant = "solid" | "subtle" | "outline";
 export type AlertEntrance = "fade" | "slide-down" | "slide-left" | "none";
 export type AlertAnimation = "pulse" | "glow" | "shake" | "none";
 
-export interface CuiAlertProps extends HideableProps, ColorableProps {
+export interface CuiAlertProps extends HideableProps, ColorableProps, LiveRegionProps {
   /** Visual variant */
   variant?: AlertVariant;
   /** Title text */
@@ -34,12 +34,6 @@ export interface CuiAlertProps extends HideableProps, ColorableProps {
   animation?: AlertAnimation;
   /** Border radius */
   rounded?: CuiRounded;
-  /**
-   * Screen-reader live-region mode. Defaults from `color`: `error` → assertive
-   * (`role="alert"`), everything else → polite (`role="status"`). Set `"off"`
-   * for purely decorative/static alerts that shouldn't be announced.
-   */
-  live?: LiveRegionMode;
 }
 
 const props = withDefaults(defineProps<CuiAlertProps>(), {

--- a/packages/clean-ui/src/components/CuiAlert.vue
+++ b/packages/clean-ui/src/components/CuiAlert.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, onUnmounted, computed } from "vue";
 import type { HideableProps, ColorableProps, CuiRounded } from "../types/common";
 import CuiIcon from "./CuiIcon.vue";
 import { COLOR_ICON_MAP } from "../utils/colorIconMap";
+import { resolveLiveRegion, type LiveRegionMode } from "../utils/liveRegion";
 
 const radiusMap: Record<CuiRounded, string> = {
   none: "0",
@@ -33,6 +34,12 @@ export interface CuiAlertProps extends HideableProps, ColorableProps {
   animation?: AlertAnimation;
   /** Border radius */
   rounded?: CuiRounded;
+  /**
+   * Screen-reader live-region mode. Defaults from `color`: `error` → assertive
+   * (`role="alert"`), everything else → polite (`role="status"`). Set `"off"`
+   * for purely decorative/static alerts that shouldn't be announced.
+   */
+  live?: LiveRegionMode;
 }
 
 const props = withDefaults(defineProps<CuiAlertProps>(), {
@@ -116,6 +123,8 @@ const alertStyle = computed(() => {
 });
 
 const defaultIconName = computed(() => COLOR_ICON_MAP[props.color] ?? "info");
+
+const liveAttrs = computed(() => resolveLiveRegion(props.color, props.live));
 </script>
 
 <template>
@@ -129,7 +138,7 @@ const defaultIconName = computed(() => COLOR_ICON_MAP[props.color] ?? "info");
       animation !== 'none' ? `cui-alert--${animation}` : '',
     ]"
     :style="alertStyle"
-    role="alert"
+    v-bind="liveAttrs"
   >
     <!-- Icon -->
     <div v-if="!noIcon" class="cui-alert__icon">

--- a/packages/clean-ui/src/components/CuiBanner.vue
+++ b/packages/clean-ui/src/components/CuiBanner.vue
@@ -4,6 +4,7 @@ import type { HideableProps, ColorableProps } from "../types/common";
 import CuiIcon from "./CuiIcon.vue";
 import CuiButton from "./CuiButton.vue";
 import { COLOR_ICON_MAP } from "../utils/colorIconMap";
+import { resolveLiveRegion, type LiveRegionMode } from "../utils/liveRegion";
 
 export type BannerPosition = "top" | "bottom";
 export type BannerVariant = "solid" | "subtle";
@@ -19,6 +20,12 @@ export interface CuiBannerProps extends HideableProps, ColorableProps {
   noIcon?: boolean;
   /** Persist dismissal to localStorage under this key */
   storageKey?: string;
+  /**
+   * Screen-reader live-region mode. Defaults from `color`: `error` → assertive
+   * (`role="alert"`), everything else → polite (`role="status"`). Set `"off"`
+   * for purely promotional banners that shouldn't be announced.
+   */
+  live?: LiveRegionMode;
 }
 
 const props = withDefaults(defineProps<CuiBannerProps>(), {
@@ -48,6 +55,8 @@ function dismiss() {
 }
 
 const iconName = computed(() => COLOR_ICON_MAP[props.color] ?? "info");
+
+const liveAttrs = computed(() => resolveLiveRegion(props.color, props.live));
 
 const containerStyle = computed(() => {
   const s: Record<string, string> = {
@@ -79,7 +88,7 @@ const containerStyle = computed(() => {
 </script>
 
 <template>
-  <div v-if="!dismissed" v-show="!hidden" :style="containerStyle" role="alert">
+  <div v-if="!dismissed" v-show="!hidden" :style="containerStyle" v-bind="liveAttrs">
     <!-- Icon -->
     <CuiIcon v-if="!noIcon" :name="iconName" size="1.125rem" style="flex-shrink: 0;" />
 

--- a/packages/clean-ui/src/components/CuiBanner.vue
+++ b/packages/clean-ui/src/components/CuiBanner.vue
@@ -1,15 +1,15 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
-import type { HideableProps, ColorableProps } from "../types/common";
+import type { HideableProps, ColorableProps, LiveRegionProps } from "../types/common";
 import CuiIcon from "./CuiIcon.vue";
 import CuiButton from "./CuiButton.vue";
 import { COLOR_ICON_MAP } from "../utils/colorIconMap";
-import { resolveLiveRegion, type LiveRegionMode } from "../utils/liveRegion";
+import { resolveLiveRegion } from "../utils/liveRegion";
 
 export type BannerPosition = "top" | "bottom";
 export type BannerVariant = "solid" | "subtle";
 
-export interface CuiBannerProps extends HideableProps, ColorableProps {
+export interface CuiBannerProps extends HideableProps, ColorableProps, LiveRegionProps {
   /** Visual variant */
   variant?: BannerVariant;
   /** Sticky position */
@@ -20,12 +20,6 @@ export interface CuiBannerProps extends HideableProps, ColorableProps {
   noIcon?: boolean;
   /** Persist dismissal to localStorage under this key */
   storageKey?: string;
-  /**
-   * Screen-reader live-region mode. Defaults from `color`: `error` → assertive
-   * (`role="alert"`), everything else → polite (`role="status"`). Set `"off"`
-   * for purely promotional banners that shouldn't be announced.
-   */
-  live?: LiveRegionMode;
 }
 
 const props = withDefaults(defineProps<CuiBannerProps>(), {

--- a/packages/clean-ui/src/components/CuiToast.vue
+++ b/packages/clean-ui/src/components/CuiToast.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted } from "vue";
-import type { CuiColor, HideableProps, ColorableProps } from "../types/common";
+import type { CuiColor, HideableProps, ColorableProps, LiveRegionProps } from "../types/common";
 import CuiIcon from "./CuiIcon.vue";
 import type { AlertAnimation, AlertVariant } from "./CuiAlert.vue";
 import { COLOR_ICON_MAP } from "../utils/colorIconMap";
-import { resolveLiveRegion, type LiveRegionMode } from "../utils/liveRegion";
+import { resolveLiveRegion } from "../utils/liveRegion";
 
-export interface CuiToastProps extends HideableProps, ColorableProps {
+export interface CuiToastProps extends HideableProps, ColorableProps, LiveRegionProps {
   /** Internal toast id */
   toastId?: string;
   /** Title text */
@@ -29,11 +29,6 @@ export interface CuiToastProps extends HideableProps, ColorableProps {
   noIcon?: boolean;
   /** Whether this toast is the topmost (active) — timer only runs when true */
   active?: boolean;
-  /**
-   * Screen-reader live-region mode. Defaults from `color`: `error` → assertive
-   * (`role="alert"`), everything else → polite (`role="status"`).
-   */
-  live?: LiveRegionMode;
 }
 
 const props = withDefaults(defineProps<CuiToastProps>(), {

--- a/packages/clean-ui/src/components/CuiToast.vue
+++ b/packages/clean-ui/src/components/CuiToast.vue
@@ -4,6 +4,7 @@ import type { CuiColor, HideableProps, ColorableProps } from "../types/common";
 import CuiIcon from "./CuiIcon.vue";
 import type { AlertAnimation, AlertVariant } from "./CuiAlert.vue";
 import { COLOR_ICON_MAP } from "../utils/colorIconMap";
+import { resolveLiveRegion, type LiveRegionMode } from "../utils/liveRegion";
 
 export interface CuiToastProps extends HideableProps, ColorableProps {
   /** Internal toast id */
@@ -28,6 +29,11 @@ export interface CuiToastProps extends HideableProps, ColorableProps {
   noIcon?: boolean;
   /** Whether this toast is the topmost (active) — timer only runs when true */
   active?: boolean;
+  /**
+   * Screen-reader live-region mode. Defaults from `color`: `error` → assertive
+   * (`role="alert"`), everything else → polite (`role="status"`).
+   */
+  live?: LiveRegionMode;
 }
 
 const props = withDefaults(defineProps<CuiToastProps>(), {
@@ -141,6 +147,8 @@ const toastStyle = computed(() => {
 });
 
 const defaultIconName = computed(() => COLOR_ICON_MAP[props.color] ?? "info");
+
+const liveAttrs = computed(() => resolveLiveRegion(props.color, props.live));
 </script>
 
 <template>
@@ -151,7 +159,7 @@ const defaultIconName = computed(() => COLOR_ICON_MAP[props.color] ?? "info");
       animation !== 'none' ? `cui-toast--${animation}` : '',
     ]"
     :style="toastStyle"
-    role="alert"
+    v-bind="liveAttrs"
     @mouseenter="onMouseEnter"
     @mouseleave="onMouseLeave"
   >

--- a/packages/clean-ui/src/components/CuiToastProvider.vue
+++ b/packages/clean-ui/src/components/CuiToastProvider.vue
@@ -128,6 +128,7 @@ const visibleToasts = computed(() => {
           :animation="toast.animation"
           :icon="toast.icon"
           :no-icon="toast.noIcon"
+          :live="toast.live"
           :active="index === visibleToasts.length - 1"
           @dismiss="state.dismiss(toast.id)"
         />

--- a/packages/clean-ui/src/components/__tests__/liveRegion.test.ts
+++ b/packages/clean-ui/src/components/__tests__/liveRegion.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import { resolveLiveRegion } from "../../utils/liveRegion";
+import CuiAlert from "../CuiAlert.vue";
+import CuiBanner from "../CuiBanner.vue";
+import CuiToast from "../CuiToast.vue";
+
+describe("resolveLiveRegion", () => {
+  it("maps error to an assertive alert", () => {
+    expect(resolveLiveRegion("error")).toEqual({
+      role: "alert",
+      "aria-live": "assertive",
+      "aria-atomic": "true",
+    });
+  });
+
+  it("maps non-error severities to a polite status", () => {
+    for (const color of ["success", "info", "warning", "primary", "surface"] as const) {
+      expect(resolveLiveRegion(color)).toEqual({
+        role: "status",
+        "aria-live": "polite",
+        "aria-atomic": "true",
+      });
+    }
+  });
+
+  it("honors an explicit override over the color default", () => {
+    expect(resolveLiveRegion("success", "assertive").role).toBe("alert");
+    expect(resolveLiveRegion("error", "polite").role).toBe("status");
+  });
+
+  it('emits no role and aria-live="off" when disabled', () => {
+    expect(resolveLiveRegion("error", "off")).toEqual({ "aria-live": "off" });
+  });
+});
+
+describe("feedback components expose live-region semantics", () => {
+  it("CuiAlert: error → alert/assertive, success → status/polite", () => {
+    const err = mount(CuiAlert, { props: { color: "error" } });
+    expect(err.attributes("role")).toBe("alert");
+    expect(err.attributes("aria-live")).toBe("assertive");
+
+    const ok = mount(CuiAlert, { props: { color: "success" } });
+    expect(ok.attributes("role")).toBe("status");
+    expect(ok.attributes("aria-live")).toBe("polite");
+  });
+
+  it("CuiAlert: live=off removes the live region", () => {
+    const wrapper = mount(CuiAlert, { props: { color: "error", live: "off" } });
+    expect(wrapper.attributes("role")).toBeUndefined();
+    expect(wrapper.attributes("aria-live")).toBe("off");
+  });
+
+  it("CuiBanner: default (primary) is polite, error is assertive", () => {
+    const banner = mount(CuiBanner);
+    expect(banner.attributes("role")).toBe("status");
+    const err = mount(CuiBanner, { props: { color: "error" } });
+    expect(err.attributes("role")).toBe("alert");
+  });
+
+  it("CuiToast: success → status, error → alert", () => {
+    const ok = mount(CuiToast, { props: { color: "success", autoDismiss: 0 } });
+    expect(ok.attributes("role")).toBe("status");
+    expect(ok.attributes("aria-live")).toBe("polite");
+
+    const err = mount(CuiToast, { props: { color: "error", autoDismiss: 0 } });
+    expect(err.attributes("role")).toBe("alert");
+    expect(err.attributes("aria-live")).toBe("assertive");
+  });
+});

--- a/packages/clean-ui/src/components/toast-context.ts
+++ b/packages/clean-ui/src/components/toast-context.ts
@@ -1,6 +1,7 @@
 import { ref, type InjectionKey, type Ref } from "vue";
 import type { CuiColor } from "../types/common";
 import type { AlertAnimation } from "./CuiAlert.vue";
+import type { LiveRegionMode } from "../utils/liveRegion";
 
 export type ToastPosition =
   | "top-right"
@@ -35,12 +36,18 @@ export interface ToastOptions {
   icon?: string;
   /** Hide the default role icon */
   noIcon?: boolean;
+  /**
+   * Screen-reader live-region mode. Defaults from `color`: `error` → assertive
+   * (`role="alert"`), everything else → polite (`role="status"`).
+   */
+  live?: LiveRegionMode;
 }
 
 export interface ToastInstance extends Required<Pick<ToastOptions, "id" | "color" | "variant" | "dismissible" | "autoDismiss" | "showProgress" | "animation" | "noIcon">> {
   title?: string;
   description?: string;
   icon?: string;
+  live?: LiveRegionMode;
   createdAt: number;
 }
 
@@ -80,6 +87,7 @@ export function createToastState(
       animation: options.animation ?? "none",
       icon: options.icon,
       noIcon: options.noIcon ?? false,
+      live: options.live,
       createdAt: Date.now(),
     };
 

--- a/packages/clean-ui/src/components/toast-context.ts
+++ b/packages/clean-ui/src/components/toast-context.ts
@@ -1,7 +1,6 @@
 import { ref, type InjectionKey, type Ref } from "vue";
-import type { CuiColor } from "../types/common";
+import type { CuiColor, LiveRegionMode } from "../types/common";
 import type { AlertAnimation } from "./CuiAlert.vue";
-import type { LiveRegionMode } from "../utils/liveRegion";
 
 export type ToastPosition =
   | "top-right"

--- a/packages/clean-ui/src/index.ts
+++ b/packages/clean-ui/src/index.ts
@@ -114,6 +114,8 @@ export type {
   SizeableProps,
   DisableableProps,
   FormControlProps,
+  LiveRegionMode,
+  LiveRegionProps,
 } from "./types/common";
 export type { CuiButtonProps, ButtonVariant } from "./components/CuiButton.vue";
 export type { CuiButtonGroupProps, ButtonGroupOrientation } from "./components/CuiButtonGroup.vue";
@@ -146,7 +148,7 @@ export type {
 } from "./components/form-context";
 export { zodResolver, valibotResolver } from "./utils/resolvers";
 export { resolveLiveRegion } from "./utils/liveRegion";
-export type { LiveRegionMode, LiveRegionAttrs } from "./utils/liveRegion";
+export type { LiveRegionAttrs } from "./utils/liveRegion";
 export type { CuiFieldsetProps, FieldsetVariant } from "./components/CuiFieldset.vue";
 export type { CuiBadgeProps, BadgeVariant, BadgeAnimation } from "./components/CuiBadge.vue";
 export type { CuiAlertProps, AlertVariant, AlertEntrance, AlertAnimation } from "./components/CuiAlert.vue";

--- a/packages/clean-ui/src/index.ts
+++ b/packages/clean-ui/src/index.ts
@@ -145,6 +145,8 @@ export type {
   FormValidateOn,
 } from "./components/form-context";
 export { zodResolver, valibotResolver } from "./utils/resolvers";
+export { resolveLiveRegion } from "./utils/liveRegion";
+export type { LiveRegionMode, LiveRegionAttrs } from "./utils/liveRegion";
 export type { CuiFieldsetProps, FieldsetVariant } from "./components/CuiFieldset.vue";
 export type { CuiBadgeProps, BadgeVariant, BadgeAnimation } from "./components/CuiBadge.vue";
 export type { CuiAlertProps, AlertVariant, AlertEntrance, AlertAnimation } from "./components/CuiAlert.vue";

--- a/packages/clean-ui/src/types/common.ts
+++ b/packages/clean-ui/src/types/common.ts
@@ -63,6 +63,25 @@ export interface DisableableProps {
   disabled?: boolean;
 }
 
+/**
+ * Screen-reader live-region mode for ephemeral feedback components
+ * (Toast / Alert / Banner).
+ *  - `"polite"`     — announced when the screen reader is idle (`role="status"`)
+ *  - `"assertive"`  — interrupts immediately (`role="alert"`)
+ *  - `"off"`        — no live region (decorative / static content)
+ */
+export type LiveRegionMode = "off" | "polite" | "assertive";
+
+/** Components that announce to screen readers via an ARIA live region. */
+export interface LiveRegionProps {
+  /**
+   * Screen-reader live-region mode. Defaults from `color`: `error` → assertive
+   * (`role="alert"`), everything else → polite (`role="status"`). Set `"off"`
+   * for purely decorative/static feedback that shouldn't be announced.
+   */
+  live?: LiveRegionMode;
+}
+
 /** Shared surface for form controls (label/description/validation/readonly). */
 export interface FormControlProps extends DisableableProps {
   /** Label text */

--- a/packages/clean-ui/src/utils/liveRegion.ts
+++ b/packages/clean-ui/src/utils/liveRegion.ts
@@ -1,13 +1,4 @@
-import type { CuiColor } from "../types/common";
-
-/**
- * Live-region announcement mode for ephemeral feedback components
- * (Toast / Alert / Banner).
- *  - `"polite"`     — announced when the screen reader is idle (`role="status"`)
- *  - `"assertive"`  — interrupts the screen reader immediately (`role="alert"`)
- *  - `"off"`        — no live region (decorative / static content)
- */
-export type LiveRegionMode = "off" | "polite" | "assertive";
+import type { CuiColor, LiveRegionMode } from "../types/common";
 
 /** ARIA attributes for a live region — spread onto the root element via `v-bind`. */
 export interface LiveRegionAttrs {

--- a/packages/clean-ui/src/utils/liveRegion.ts
+++ b/packages/clean-ui/src/utils/liveRegion.ts
@@ -1,0 +1,49 @@
+import type { CuiColor } from "../types/common";
+
+/**
+ * Live-region announcement mode for ephemeral feedback components
+ * (Toast / Alert / Banner).
+ *  - `"polite"`     — announced when the screen reader is idle (`role="status"`)
+ *  - `"assertive"`  — interrupts the screen reader immediately (`role="alert"`)
+ *  - `"off"`        — no live region (decorative / static content)
+ */
+export type LiveRegionMode = "off" | "polite" | "assertive";
+
+/** ARIA attributes for a live region — spread onto the root element via `v-bind`. */
+export interface LiveRegionAttrs {
+  role?: "alert" | "status";
+  "aria-live": LiveRegionMode;
+  "aria-atomic"?: "true";
+}
+
+/** Color roles that warrant an interrupting (assertive) announcement by default. */
+const ASSERTIVE_COLORS: ReadonlySet<CuiColor> = new Set<CuiColor>(["error"]);
+
+/**
+ * Resolve ARIA live-region attributes for a feedback component from its color
+ * severity, with an optional explicit override.
+ *
+ *  - `error`           → assertive (`role="alert"`, interrupts)
+ *  - everything else   → polite    (`role="status"`, waits for idle)
+ *  - override `"off"`  → no live region at all
+ *
+ * `aria-atomic="true"` ensures the whole message is re-read on change rather
+ * than just the diff (also implied by `role`, set explicitly for older AT).
+ */
+export function resolveLiveRegion(
+  color: CuiColor,
+  override?: LiveRegionMode,
+): LiveRegionAttrs {
+  const mode: LiveRegionMode =
+    override ?? (ASSERTIVE_COLORS.has(color) ? "assertive" : "polite");
+
+  if (mode === "off") {
+    return { "aria-live": "off" };
+  }
+
+  return {
+    role: mode === "assertive" ? "alert" : "status",
+    "aria-live": mode,
+    "aria-atomic": "true",
+  };
+}


### PR DESCRIPTION
Closes #11.

## Problem
`CuiToast`, `CuiAlert`, and `CuiBanner` all hardcoded `role="alert"`. That means *every* toast/alert/banner — including success confirmations and info banners — interrupted screen-reader users **assertively**, and decorative/promotional banners announced when they shouldn't.

## Fix
Live-region semantics now derive from severity (with `aria-atomic="true"` so the whole message is read):

| Severity | role | aria-live |
|---|---|---|
| `error` | `alert` | `assertive` |
| everything else (success/info/warning/neutral) | `status` | `polite` |

A new `live` prop (`"off" | "polite" | "assertive"`) overrides per instance — `"off"` silences decorative alerts / promotional banners.

A shared helper `utils/liveRegion.ts` (`resolveLiveRegion(color, override?)`) keeps the three components consistent and is unit-tested. The toast pipeline threads `live` through `ToastOptions → provider → CuiToast`.

**Announcement timing:** `CuiToastProvider`'s container is mounted for the app lifetime (persistent live region), and errors use `role="alert"` which announces reliably on insertion.

## Acceptance criteria
- [x] Toast/Alert/Banner expose appropriate live-region roles
- [x] Verified announcement semantics — unit tests assert the rendered `role`/`aria-live` on all three components for error vs non-error vs `off` (see caveat)

## Files
- `utils/liveRegion.ts` — new shared helper + exports
- `CuiAlert` / `CuiToast` / `CuiBanner` — derive `role`/`aria-live`, add `live` prop
- `toast-context.ts` + `CuiToastProvider.vue` — thread `live`
- `__tests__/liveRegion.test.ts` — helper mapping + rendered ARIA (8 tests)
- docs: `live` prop documented on Alert/Banner/Toast pages

## Verification
- New tests: 8/8 pass
- Library + docs `vue-tsc` type-check clean; library build passes

## Notes for the reviewer
- The acceptance criterion mentions a screen-reader/axe check. I verified the **rendered ARIA attributes** via unit tests (the automatable part); a manual NVDA/VoiceOver pass is still worth doing before release, especially to confirm `polite` toasts announce on insertion across SRs. If they don't on some SR, the fallback is a persistent visually-hidden dual-live-region in the provider — happy to add if testing shows it's needed.
- **Out of scope / pre-existing:** `CuiButton.test.ts` has 3 failing tests on `develop` (asserting old Tailwind classes `bg-primary-500`/`border`/`h-12` that the button no longer emits since it moved to `cui-button` + inline styles). Untouched by this PR — flagging so it's on the radar.