### PR TITLE
test: real test suite — smoke coverage, interactive behavior tests, CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, master]
+  push:
+    branches: [develop, master]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Type-check + build the library (also emits .d.ts via vue-tsc)
+      - name: Build library
+        run: pnpm --filter @itguy614/clean-ui build
+
+      # Unit + smoke tests
+      - name: Run tests
+        run: pnpm --filter @itguy614/clean-ui test
+
+      # Type-check the docs app
+      - name: Type-check docs
+        run: pnpm --filter @itguy614/clean-ui-docs exec vue-tsc --noEmit

--- a/packages/clean-ui/src/components/CuiConfirmDialog.vue
+++ b/packages/clean-ui/src/components/CuiConfirmDialog.vue
@@ -96,7 +96,7 @@ function onCancel() {
 </script>
 
 <template>
-  <CuiModal v-show="!hidden" :visible="visible" size="sm" no-close-button @update:visible="emit('update:visible', $event)">
+  <CuiModal :hidden="hidden" :visible="visible" size="sm" no-close-button @update:visible="emit('update:visible', $event)">
     <!-- Custom header with icon badge -->
     <div
       :style="{

--- a/packages/clean-ui/src/components/__tests__/CuiAccordion.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiAccordion.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import { h } from "vue";
+import CuiAccordion from "../CuiAccordion.vue";
+import CuiAccordionItem from "../CuiAccordionItem.vue";
+
+function makeAccordion(accordionProps: Record<string, unknown> = {}) {
+  return mount(CuiAccordion, {
+    props: accordionProps,
+    slots: {
+      default: () => [
+        h(CuiAccordionItem, { value: "a", label: "First" }, () => "Panel A"),
+        h(CuiAccordionItem, { value: "b", label: "Second" }, () => "Panel B"),
+        h(CuiAccordionItem, { value: "c", label: "Third" }, () => "Panel C"),
+      ],
+    },
+  });
+}
+
+describe("CuiAccordion", () => {
+  it("expands an item on header (trigger) click", async () => {
+    const wrapper = makeAccordion();
+    const triggers = wrapper.findAll(".cui-accordion-item__trigger");
+    expect(triggers[0].attributes("aria-expanded")).toBe("false");
+
+    await triggers[0].trigger("click");
+
+    expect(triggers[0].attributes("aria-expanded")).toBe("true");
+    expect(wrapper.findAll(".cui-accordion-item")[0].classes()).toContain(
+      "cui-accordion-item--open",
+    );
+  });
+
+  it("collapses an open item when its trigger is clicked again", async () => {
+    const wrapper = makeAccordion();
+    const trigger = wrapper.findAll(".cui-accordion-item__trigger")[0];
+
+    await trigger.trigger("click");
+    expect(trigger.attributes("aria-expanded")).toBe("true");
+
+    await trigger.trigger("click");
+    expect(trigger.attributes("aria-expanded")).toBe("false");
+  });
+
+  it("only keeps one item open at a time by default (single mode)", async () => {
+    const wrapper = makeAccordion();
+    const triggers = wrapper.findAll(".cui-accordion-item__trigger");
+
+    await triggers[0].trigger("click");
+    await triggers[1].trigger("click");
+
+    expect(triggers[0].attributes("aria-expanded")).toBe("false");
+    expect(triggers[1].attributes("aria-expanded")).toBe("true");
+  });
+
+  it("keeps multiple items open when multiple is true", async () => {
+    const wrapper = makeAccordion({ multiple: true });
+    const triggers = wrapper.findAll(".cui-accordion-item__trigger");
+
+    await triggers[0].trigger("click");
+    await triggers[1].trigger("click");
+
+    expect(triggers[0].attributes("aria-expanded")).toBe("true");
+    expect(triggers[1].attributes("aria-expanded")).toBe("true");
+  });
+
+  it("emits update:modelValue with the open values on toggle", async () => {
+    const wrapper = makeAccordion({ multiple: true });
+    const triggers = wrapper.findAll(".cui-accordion-item__trigger");
+
+    await triggers[2].trigger("click");
+    await triggers[0].trigger("click");
+
+    const emitted = wrapper.emitted("update:modelValue");
+    expect(emitted).toBeTruthy();
+    expect(emitted![emitted!.length - 1][0]).toEqual(["c", "a"]);
+  });
+
+  it("respects an externally controlled v-model (modelValue prop)", async () => {
+    const wrapper = makeAccordion({ modelValue: ["b"] });
+    const triggers = wrapper.findAll(".cui-accordion-item__trigger");
+
+    expect(triggers[1].attributes("aria-expanded")).toBe("true");
+    expect(triggers[0].attributes("aria-expanded")).toBe("false");
+
+    await wrapper.setProps({ modelValue: ["a"] });
+
+    expect(triggers[0].attributes("aria-expanded")).toBe("true");
+    expect(triggers[1].attributes("aria-expanded")).toBe("false");
+  });
+
+  it("does not toggle a disabled item", async () => {
+    const wrapper = mount(CuiAccordion, {
+      slots: {
+        default: () => [
+          h(CuiAccordionItem, { value: "a", label: "First", disabled: true }, () => "Panel A"),
+        ],
+      },
+    });
+    const trigger = wrapper.find(".cui-accordion-item__trigger");
+
+    await trigger.trigger("click");
+
+    expect(trigger.attributes("aria-expanded")).toBe("false");
+    expect(wrapper.emitted("update:modelValue")).toBeFalsy();
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiBadge.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiBadge.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import CuiBadge from "../CuiBadge.vue";
+
+describe("CuiBadge", () => {
+  it("does not render a remove button by default", () => {
+    const wrapper = mount(CuiBadge, { slots: { default: "Tag" } });
+    expect(wrapper.find(".cui-badge__remove").exists()).toBe(false);
+  });
+
+  it("renders a remove button when removable", () => {
+    const wrapper = mount(CuiBadge, {
+      props: { removable: true },
+      slots: { default: "Tag" },
+    });
+    const btn = wrapper.find(".cui-badge__remove");
+    expect(btn.exists()).toBe(true);
+    expect(btn.attributes("aria-label")).toBeTruthy();
+  });
+
+  it("emits remove when the remove button is clicked", async () => {
+    const wrapper = mount(CuiBadge, {
+      props: { removable: true },
+      slots: { default: "Tag" },
+    });
+    await wrapper.find(".cui-badge__remove").trigger("click");
+    expect(wrapper.emitted("remove")).toHaveLength(1);
+  });
+
+  it("does not emit remove without interaction", () => {
+    const wrapper = mount(CuiBadge, {
+      props: { removable: true },
+      slots: { default: "Tag" },
+    });
+    expect(wrapper.emitted("remove")).toBeUndefined();
+  });
+
+  it("renders slot content in standard mode", () => {
+    const wrapper = mount(CuiBadge, { slots: { default: "New" } });
+    expect(wrapper.text()).toContain("New");
+  });
+
+  it("renders a dot (no remove button, no content) in dot mode", () => {
+    const wrapper = mount(CuiBadge, {
+      props: { dot: true, removable: true },
+      slots: { default: "ignored" },
+    });
+    expect(wrapper.find(".cui-badge__dot").exists()).toBe(true);
+    // dot template branch has no remove button regardless of removable
+    expect(wrapper.find(".cui-badge__remove").exists()).toBe(false);
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiBreadcrumb.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiBreadcrumb.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import { defineComponent, nextTick } from "vue";
+import CuiBreadcrumb from "../CuiBreadcrumb.vue";
+import CuiBreadcrumbItem from "../CuiBreadcrumbItem.vue";
+
+// CuiBreadcrumbItem detects whether it is the last item via a querySelectorAll
+// on its parent <ol> in onMounted, so the component must be attached to a real
+// document, and the reactive isLast update needs a couple of ticks to flush.
+function makeHost(extra: { breadcrumbProps?: string } = {}) {
+  return defineComponent({
+    components: { CuiBreadcrumb, CuiBreadcrumbItem },
+    template: `
+      <CuiBreadcrumb ${extra.breadcrumbProps ?? ""}>
+        <CuiBreadcrumbItem href="/">Home</CuiBreadcrumbItem>
+        <CuiBreadcrumbItem href="/library">Library</CuiBreadcrumbItem>
+        <CuiBreadcrumbItem>Current</CuiBreadcrumbItem>
+      </CuiBreadcrumb>
+    `,
+  });
+}
+
+async function mountHost(extra: { breadcrumbProps?: string } = {}) {
+  const wrapper = mount(makeHost(extra), { attachTo: document.body });
+  await nextTick();
+  await nextTick();
+  return wrapper;
+}
+
+describe("CuiBreadcrumb + CuiBreadcrumbItem", () => {
+  it("renders a nav with the breadcrumb aria-label and one li per item", async () => {
+    const wrapper = await mountHost();
+
+    const nav = wrapper.find("nav.cui-breadcrumb");
+    expect(nav.attributes("aria-label")).toBe("Breadcrumb");
+
+    const items = wrapper.findAll("li.cui-breadcrumb-item");
+    expect(items).toHaveLength(3);
+
+    wrapper.unmount();
+  });
+
+  it("renders non-last items as links with their href", async () => {
+    const wrapper = await mountHost();
+
+    const links = wrapper.findAll("a.cui-breadcrumb-item__link");
+    expect(links).toHaveLength(2);
+    expect(links[0].attributes("href")).toBe("/");
+    expect(links[0].text()).toBe("Home");
+    expect(links[1].attributes("href")).toBe("/library");
+
+    wrapper.unmount();
+  });
+
+  it("marks only the last item as current (aria-current=page, current class, span tag)", async () => {
+    const wrapper = await mountHost();
+
+    const currents = wrapper.findAll('[aria-current="page"]');
+    expect(currents).toHaveLength(1);
+    expect(currents[0].text()).toBe("Current");
+    expect(currents[0].classes()).toContain("cui-breadcrumb-item__link--current");
+    expect(currents[0].element.tagName).toBe("SPAN");
+
+    wrapper.unmount();
+  });
+
+  it("renders a separator after every item except the last", async () => {
+    const wrapper = await mountHost();
+
+    const seps = wrapper.findAll(".cui-breadcrumb-item__separator");
+    expect(seps).toHaveLength(2);
+    expect(seps[0].text()).toBe("/");
+    expect(seps[0].attributes("aria-hidden")).toBe("true");
+
+    wrapper.unmount();
+  });
+
+  it("honors a custom separator provided via the breadcrumb context", async () => {
+    const wrapper = await mountHost({ breadcrumbProps: 'separator="›"' });
+
+    const seps = wrapper.findAll(".cui-breadcrumb-item__separator");
+    expect(seps).toHaveLength(2);
+    expect(seps.map((s) => s.text())).toEqual(["›", "›"]);
+
+    wrapper.unmount();
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiButton.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiButton.test.ts
@@ -10,30 +10,42 @@ describe("CuiButton", () => {
     expect(wrapper.text()).toBe("Click me");
   });
 
-  it("applies solid variant classes by default", () => {
+  it("renders as a <button> with the cui-button class by default", () => {
     const wrapper = mount(CuiButton);
-    expect(wrapper.classes()).toContain("bg-primary-500");
+    expect(wrapper.element.tagName).toBe("BUTTON");
+    expect(wrapper.classes()).toContain("cui-button");
   });
 
-  it("applies outline variant classes", () => {
-    const wrapper = mount(CuiButton, {
-      props: { variant: "outline" },
-    });
-    expect(wrapper.classes()).toContain("border");
+  it("renders as an <a> when href is set", () => {
+    const wrapper = mount(CuiButton, { props: { href: "/foo" } });
+    expect(wrapper.element.tagName).toBe("A");
+    expect(wrapper.attributes("href")).toBe("/foo");
   });
 
-  it("applies size classes", () => {
-    const wrapper = mount(CuiButton, {
-      props: { size: "lg" },
-    });
-    expect(wrapper.classes()).toContain("h-12");
+  it("applies the size scale to the inline height", () => {
+    const lg = mount(CuiButton, { props: { size: "lg" } });
+    expect(lg.attributes("style")).toContain("3rem"); // BUTTON_SIZE_SCALE.lg.height
+    const sm = mount(CuiButton, { props: { size: "sm" } });
+    expect(sm.attributes("style")).toContain("2rem"); // BUTTON_SIZE_SCALE.sm.height
   });
 
-  it("sets disabled attribute", () => {
+  it("renders distinct styling per variant", () => {
+    const solid = mount(CuiButton, { props: { variant: "solid" } });
+    const outline = mount(CuiButton, { props: { variant: "outline" } });
+    expect(solid.attributes("style")).not.toBe(outline.attributes("style"));
+  });
+
+  it("sets disabled attribute and disabled class", () => {
     const wrapper = mount(CuiButton, {
       props: { disabled: true },
     });
     expect(wrapper.attributes("disabled")).toBeDefined();
+    expect(wrapper.classes()).toContain("cui-button--disabled");
+  });
+
+  it("sets aria-busy when loading", () => {
+    const wrapper = mount(CuiButton, { props: { loading: true } });
+    expect(wrapper.attributes("aria-busy")).toBe("true");
   });
 
   it("emits click event", async () => {

--- a/packages/clean-ui/src/components/__tests__/CuiCheckboxGroup.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiCheckboxGroup.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import { defineComponent, h, ref } from "vue";
+import CuiCheckboxGroup from "../CuiCheckboxGroup.vue";
+import CuiCheckbox from "../CuiCheckbox.vue";
+
+describe("CuiCheckboxGroup", () => {
+  it("checking a child checkbox adds its value to the group v-model array", async () => {
+    const Host = defineComponent({
+      setup() {
+        const selected = ref<Array<string | number>>([]);
+        return { selected };
+      },
+      render() {
+        return h(
+          CuiCheckboxGroup,
+          {
+            modelValue: this.selected,
+            "onUpdate:modelValue": (v: Array<string | number>) => (this.selected = v),
+          },
+          () => [
+            h(CuiCheckbox, { value: "a", label: "A" }),
+            h(CuiCheckbox, { value: "b", label: "B" }),
+          ],
+        );
+      },
+    });
+
+    const wrapper = mount(Host);
+    const boxes = wrapper.findAllComponents(CuiCheckbox);
+    expect(boxes).toHaveLength(2);
+
+    await boxes[0].trigger("click");
+    expect(wrapper.vm.selected).toEqual(["a"]);
+
+    await boxes[1].trigger("click");
+    expect(wrapper.vm.selected).toEqual(["a", "b"]);
+  });
+
+  it("clicking a checked child removes its value from the array", async () => {
+    const Host = defineComponent({
+      setup() {
+        const selected = ref<Array<string | number>>(["a", "b"]);
+        return { selected };
+      },
+      render() {
+        return h(
+          CuiCheckboxGroup,
+          {
+            modelValue: this.selected,
+            "onUpdate:modelValue": (v: Array<string | number>) => (this.selected = v),
+          },
+          () => [
+            h(CuiCheckbox, { value: "a", label: "A" }),
+            h(CuiCheckbox, { value: "b", label: "B" }),
+          ],
+        );
+      },
+    });
+
+    const wrapper = mount(Host);
+    const boxes = wrapper.findAllComponents(CuiCheckbox);
+
+    await boxes[0].trigger("click");
+    expect(wrapper.vm.selected).toEqual(["b"]);
+  });
+
+  it("reflects checked state from the group model via aria-checked", () => {
+    const wrapper = mount(CuiCheckboxGroup, {
+      props: { modelValue: ["b"] },
+      slots: {
+        default: () => [
+          h(CuiCheckbox, { value: "a", label: "A" }),
+          h(CuiCheckbox, { value: "b", label: "B" }),
+        ],
+      },
+    });
+    const boxes = wrapper.findAllComponents(CuiCheckbox);
+    expect(boxes[0].attributes("aria-checked")).toBe("false");
+    expect(boxes[1].attributes("aria-checked")).toBe("true");
+  });
+
+  it("standalone checkbox uses a boolean v-model", async () => {
+    const wrapper = mount(CuiCheckbox, {
+      props: {
+        modelValue: false,
+        label: "Standalone",
+        "onUpdate:modelValue": (v: boolean) => wrapper.setProps({ modelValue: v }),
+      },
+    });
+    expect(wrapper.attributes("aria-checked")).toBe("false");
+
+    await wrapper.trigger("click");
+    expect(wrapper.emitted("update:modelValue")?.[0]).toEqual([true]);
+    expect(wrapper.attributes("aria-checked")).toBe("true");
+  });
+
+  it("a disabled group does not mutate the model when a child is clicked", async () => {
+    const Host = defineComponent({
+      setup() {
+        const selected = ref<Array<string | number>>([]);
+        return { selected };
+      },
+      render() {
+        return h(
+          CuiCheckboxGroup,
+          {
+            modelValue: this.selected,
+            disabled: true,
+            "onUpdate:modelValue": (v: Array<string | number>) => (this.selected = v),
+          },
+          () => [h(CuiCheckbox, { value: "a", label: "A" })],
+        );
+      },
+    });
+
+    const wrapper = mount(Host);
+    const box = wrapper.findComponent(CuiCheckbox);
+    expect(box.attributes("aria-disabled")).toBe("true");
+
+    await box.trigger("click");
+    expect(wrapper.vm.selected).toEqual([]);
+  });
+
+  it("auto orientation is horizontal for 2 children and vertical for 3+", () => {
+    const twoChildren = mount(CuiCheckboxGroup, {
+      slots: {
+        default: () => [
+          h(CuiCheckbox, { value: "a" }),
+          h(CuiCheckbox, { value: "b" }),
+        ],
+      },
+    });
+    expect(twoChildren.classes()).toContain("cui-checkbox-group--horizontal");
+
+    const threeChildren = mount(CuiCheckboxGroup, {
+      slots: {
+        default: () => [
+          h(CuiCheckbox, { value: "a" }),
+          h(CuiCheckbox, { value: "b" }),
+          h(CuiCheckbox, { value: "c" }),
+        ],
+      },
+    });
+    expect(threeChildren.classes()).toContain("cui-checkbox-group--vertical");
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiCombobox.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiCombobox.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import CuiCombobox from "../CuiCombobox.vue";
+import type { ComboboxOption } from "../CuiCombobox.vue";
+
+const OPTIONS: ComboboxOption[] = [
+  { value: "apple", label: "Apple" },
+  { value: "banana", label: "Banana" },
+  { value: "cherry", label: "Cherry" },
+];
+
+// The dropdown teleports to document.body. Find option rows there.
+function dropdownOptionTexts(): string[] {
+  return [...document.body.querySelectorAll("[data-index]")].map(
+    (el) => (el as HTMLElement).textContent?.trim() ?? "",
+  );
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("CuiCombobox", () => {
+  it("opens the dropdown on focus and lists all options", async () => {
+    const wrapper = mount(CuiCombobox, {
+      props: { options: OPTIONS },
+      attachTo: document.body,
+    });
+    await wrapper.find("input").trigger("focus");
+    await nextTick();
+
+    const texts = dropdownOptionTexts();
+    expect(texts).toEqual(["Apple", "Banana", "Cherry"]);
+    wrapper.unmount();
+  });
+
+  it("filters options by the typed query (case-insensitive)", async () => {
+    const wrapper = mount(CuiCombobox, {
+      props: { options: OPTIONS },
+      attachTo: document.body,
+    });
+    const input = wrapper.find("input");
+    await input.trigger("focus");
+    await input.setValue("an"); // matches "Banana"
+    await nextTick();
+
+    expect(dropdownOptionTexts()).toEqual(["Banana"]);
+    wrapper.unmount();
+  });
+
+  it("shows the no-results text when nothing matches", async () => {
+    const wrapper = mount(CuiCombobox, {
+      props: { options: OPTIONS, noResultsText: "Nada" },
+      attachTo: document.body,
+    });
+    const input = wrapper.find("input");
+    await input.trigger("focus");
+    await input.setValue("zzz");
+    await nextTick();
+
+    expect(dropdownOptionTexts()).toEqual([]);
+    expect(document.body.textContent).toContain("Nada");
+    wrapper.unmount();
+  });
+
+  it("emits update:modelValue with the option value when an option is clicked (single)", async () => {
+    const wrapper = mount(CuiCombobox, {
+      props: { options: OPTIONS },
+      attachTo: document.body,
+    });
+    await wrapper.find("input").trigger("focus");
+    await nextTick();
+
+    const cherry = [...document.body.querySelectorAll("[data-index]")].find(
+      (el) => el.textContent?.trim() === "Cherry",
+    ) as HTMLElement;
+    cherry.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await nextTick();
+
+    const emitted = wrapper.emitted("update:modelValue");
+    expect(emitted).toBeTruthy();
+    expect(emitted![0]).toEqual(["cherry"]);
+    wrapper.unmount();
+  });
+
+  it("displays the selected label in the input when closed", async () => {
+    const wrapper = mount(CuiCombobox, {
+      props: { options: OPTIONS, modelValue: "banana" },
+      attachTo: document.body,
+    });
+    await nextTick();
+    const input = wrapper.find("input").element as HTMLInputElement;
+    expect(input.value).toBe("Banana");
+    wrapper.unmount();
+  });
+
+  it("renders removable tags in multiple mode and removeTag emits the pruned array", async () => {
+    const wrapper = mount(CuiCombobox, {
+      props: { options: OPTIONS, multiple: true, modelValue: ["apple", "banana"] },
+      attachTo: document.body,
+    });
+    await nextTick();
+
+    // Two selected tags (CuiBadge with removable) render in the input area.
+    const removeButtons = wrapper.findAll(".cui-badge button, .cui-badge [aria-label]");
+    expect(removeButtons.length).toBeGreaterThanOrEqual(1);
+
+    await removeButtons[0].trigger("click");
+    const emitted = wrapper.emitted("update:modelValue");
+    expect(emitted).toBeTruthy();
+    // Removing the first tag (apple) leaves banana.
+    expect(emitted![emitted!.length - 1]).toEqual([["banana"]]);
+    wrapper.unmount();
+  });
+
+  it("does not open the dropdown when disabled", async () => {
+    const wrapper = mount(CuiCombobox, {
+      props: { options: OPTIONS, disabled: true },
+      attachTo: document.body,
+    });
+    const input = wrapper.find("input");
+    expect((input.element as HTMLInputElement).disabled).toBe(true);
+
+    await input.trigger("focus");
+    await nextTick();
+    expect(dropdownOptionTexts()).toEqual([]);
+    wrapper.unmount();
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiConfirmDialog.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiConfirmDialog.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import CuiConfirmDialog from "../CuiConfirmDialog.vue";
+import CuiButton from "../CuiButton.vue";
+import CuiInput from "../CuiInput.vue";
+
+// CuiConfirmDialog wraps CuiModal, which teleports content into <body> and opens
+// on mount via an onMounted/nextTick flush — so await flushPromises() before
+// querying. Query through the wrapper (it proxies the teleported tree).
+
+function findButtonByText(wrapper: ReturnType<typeof mount>, text: string) {
+  const btn = wrapper
+    .findAllComponents(CuiButton)
+    .find((b) => b.text().includes(text));
+  if (!btn) throw new Error(`No button with text "${text}"`);
+  return btn;
+}
+
+describe("CuiConfirmDialog", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("emits confirm when the confirm button is clicked", async () => {
+    const wrapper = mount(CuiConfirmDialog, {
+      props: { visible: true, confirmText: "Delete" },
+    });
+    await flushPromises();
+    await findButtonByText(wrapper, "Delete").trigger("click");
+    expect(wrapper.emitted("confirm")).toHaveLength(1);
+    wrapper.unmount();
+  });
+
+  it("emits cancel and requests close when the cancel button is clicked", async () => {
+    const wrapper = mount(CuiConfirmDialog, {
+      props: { visible: true, cancelText: "Cancel" },
+    });
+    await flushPromises();
+    await findButtonByText(wrapper, "Cancel").trigger("click");
+    expect(wrapper.emitted("cancel")).toHaveLength(1);
+    expect(wrapper.emitted("update:visible")?.at(-1)).toEqual([false]);
+    wrapper.unmount();
+  });
+
+  it("disables confirm until the typed word matches confirmWord, then enables it", async () => {
+    const wrapper = mount(CuiConfirmDialog, {
+      props: { visible: true, confirmText: "Delete", confirmWord: "DELETE" },
+    });
+    await flushPromises();
+
+    const confirmBtn = findButtonByText(wrapper, "Delete");
+    // Disabled initially — no matching text typed.
+    expect(confirmBtn.attributes("disabled")).toBeDefined();
+    await confirmBtn.trigger("click");
+    expect(wrapper.emitted("confirm")).toBeUndefined();
+
+    // Type the matching word (case-insensitive, trimmed).
+    await wrapper.findComponent(CuiInput).setValue("  delete  ");
+    expect(confirmBtn.attributes("disabled")).toBeUndefined();
+    await confirmBtn.trigger("click");
+    expect(wrapper.emitted("confirm")).toHaveLength(1);
+    wrapper.unmount();
+  });
+
+  it("does not render dialog content until v-model:visible is true", async () => {
+    const wrapper = mount(CuiConfirmDialog, {
+      props: { visible: false, confirmText: "Delete" },
+    });
+    await flushPromises();
+    expect(wrapper.findAllComponents(CuiButton)).toHaveLength(0);
+
+    await wrapper.setProps({ visible: true });
+    await flushPromises();
+    expect(wrapper.findAllComponents(CuiButton).length).toBeGreaterThan(0);
+    wrapper.unmount();
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiCopyButton.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiCopyButton.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import CuiCopyButton from "../CuiCopyButton.vue";
+import CuiButton from "../CuiButton.vue";
+import CuiIcon from "../CuiIcon.vue";
+
+describe("CuiCopyButton", () => {
+  let writeText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("writes the value prop to the clipboard on click", async () => {
+    const wrapper = mount(CuiCopyButton, { props: { value: "hello world" } });
+    await wrapper.getComponent(CuiButton).trigger("click");
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText).toHaveBeenCalledWith("hello world");
+    wrapper.unmount();
+  });
+
+  it("enters the copied state after a successful copy", async () => {
+    const wrapper = mount(CuiCopyButton, { props: { value: "abc" } });
+    // before copy: copy icon, configured color
+    expect(wrapper.getComponent(CuiIcon).props("name")).toBe("copy");
+    expect(wrapper.getComponent(CuiButton).props("color")).toBe("primary");
+
+    await wrapper.getComponent(CuiButton).trigger("click");
+    await vi.waitFor(() => {
+      expect(wrapper.getComponent(CuiIcon).props("name")).toBe("check");
+    });
+    // copied state swaps the button color to success
+    expect(wrapper.getComponent(CuiButton).props("color")).toBe("success");
+    wrapper.unmount();
+  });
+
+  it("reverts to the idle state after resetDelay", async () => {
+    const wrapper = mount(CuiCopyButton, { props: { value: "abc", resetDelay: 1500 } });
+    await wrapper.getComponent(CuiButton).trigger("click");
+    await vi.waitFor(() => {
+      expect(wrapper.getComponent(CuiIcon).props("name")).toBe("check");
+    });
+
+    vi.advanceTimersByTime(1500);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.getComponent(CuiIcon).props("name")).toBe("copy");
+    expect(wrapper.getComponent(CuiButton).props("color")).toBe("primary");
+    wrapper.unmount();
+  });
+
+  it("shows the copiedTooltip text once copied", async () => {
+    const wrapper = mount(CuiCopyButton, {
+      props: { value: "abc", tooltip: "Copy code", copiedTooltip: "Done!" },
+    });
+    await wrapper.getComponent(CuiButton).trigger("click");
+    await vi.waitFor(() => {
+      expect(wrapper.getComponent(CuiIcon).props("name")).toBe("check");
+    });
+    // tooltip text prop flips to the copied variant
+    const tooltip = wrapper.findAllComponents({ name: "CuiTooltip" })[0];
+    expect(tooltip.props("text")).toBe("Done!");
+    wrapper.unmount();
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiDropdown.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiDropdown.test.ts
@@ -1,10 +1,16 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { mount } from "@vue/test-utils";
-import { h } from "vue";
+import { defineComponent, h, ref } from "vue";
 import CuiDropdown from "../CuiDropdown.vue";
 import CuiDropdownTrigger from "../CuiDropdownTrigger.vue";
 import CuiDropdownMenu from "../CuiDropdownMenu.vue";
 import CuiDropdownItem from "../CuiDropdownItem.vue";
+import CuiDropdownCheckItem from "../CuiDropdownCheckItem.vue";
+import CuiDropdownRadioGroup from "../CuiDropdownRadioGroup.vue";
+import CuiDropdownRadioItem from "../CuiDropdownRadioItem.vue";
+import CuiDropdownSub from "../CuiDropdownSub.vue";
+import CuiDropdownDivider from "../CuiDropdownDivider.vue";
+import CuiDropdownHeader from "../CuiDropdownHeader.vue";
 
 // The menu teleports to document.body and renders only while open (or closing).
 const menuInBody = () => document.body.querySelector(".cui-dropdown-menu");
@@ -106,6 +112,210 @@ describe("CuiDropdown behavior", () => {
 
     expect(onSelect).not.toHaveBeenCalled();
     expect(menuInBody()).not.toBeNull();
+
+    wrapper.unmount();
+  });
+});
+
+// --- Sub-components that require CuiDropdown's injected context ---
+
+async function openMenu(wrapper: ReturnType<typeof mount>) {
+  await wrapper.find(".cui-dropdown-trigger").trigger("click");
+}
+
+describe("CuiDropdownCheckItem", () => {
+  it("toggles its checked state and emits update:modelValue on click", async () => {
+    const Host = defineComponent({
+      components: { CuiDropdown, CuiDropdownTrigger, CuiDropdownMenu, CuiDropdownCheckItem },
+      setup() {
+        const checked = ref(false);
+        return { checked };
+      },
+      template: `
+        <CuiDropdown>
+          <CuiDropdownTrigger><button>Menu</button></CuiDropdownTrigger>
+          <CuiDropdownMenu>
+            <CuiDropdownCheckItem v-model="checked">Show grid</CuiDropdownCheckItem>
+          </CuiDropdownMenu>
+        </CuiDropdown>
+      `,
+    });
+    const wrapper = mount(Host, { attachTo: document.body });
+    await openMenu(wrapper);
+
+    const item = document.body.querySelector<HTMLElement>('[role="menuitemcheckbox"]');
+    expect(item).not.toBeNull();
+    expect(item!.getAttribute("aria-checked")).toBe("false");
+
+    item!.click();
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as unknown as { checked: boolean }).checked).toBe(true);
+    expect(
+      document.body.querySelector('[role="menuitemcheckbox"]')!.getAttribute("aria-checked"),
+    ).toBe("true");
+
+    wrapper.unmount();
+  });
+
+  it("does not toggle when disabled", async () => {
+    const Host = defineComponent({
+      components: { CuiDropdown, CuiDropdownTrigger, CuiDropdownMenu, CuiDropdownCheckItem },
+      setup() {
+        const checked = ref(false);
+        return { checked };
+      },
+      template: `
+        <CuiDropdown>
+          <CuiDropdownTrigger><button>Menu</button></CuiDropdownTrigger>
+          <CuiDropdownMenu>
+            <CuiDropdownCheckItem v-model="checked" disabled>Show grid</CuiDropdownCheckItem>
+          </CuiDropdownMenu>
+        </CuiDropdown>
+      `,
+    });
+    const wrapper = mount(Host, { attachTo: document.body });
+    await openMenu(wrapper);
+
+    document.body.querySelector<HTMLElement>('[role="menuitemcheckbox"]')!.click();
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as unknown as { checked: boolean }).checked).toBe(false);
+    wrapper.unmount();
+  });
+});
+
+describe("CuiDropdownRadioGroup + CuiDropdownRadioItem", () => {
+  it("single-selects within the group and reflects aria-checked", async () => {
+    const Host = defineComponent({
+      components: {
+        CuiDropdown,
+        CuiDropdownTrigger,
+        CuiDropdownMenu,
+        CuiDropdownRadioGroup,
+        CuiDropdownRadioItem,
+      },
+      setup() {
+        const sort = ref("name");
+        return { sort };
+      },
+      template: `
+        <CuiDropdown>
+          <CuiDropdownTrigger><button>Menu</button></CuiDropdownTrigger>
+          <CuiDropdownMenu>
+            <CuiDropdownRadioGroup v-model="sort">
+              <CuiDropdownRadioItem value="name">Name</CuiDropdownRadioItem>
+              <CuiDropdownRadioItem value="date">Date</CuiDropdownRadioItem>
+            </CuiDropdownRadioGroup>
+          </CuiDropdownMenu>
+        </CuiDropdown>
+      `,
+    });
+    const wrapper = mount(Host, { attachTo: document.body });
+    await openMenu(wrapper);
+
+    const items = document.body.querySelectorAll<HTMLElement>('[role="menuitemradio"]');
+    expect(items).toHaveLength(2);
+    expect(items[0].getAttribute("aria-checked")).toBe("true");
+    expect(items[1].getAttribute("aria-checked")).toBe("false");
+
+    items[1].click();
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as unknown as { sort: string }).sort).toBe("date");
+    const after = document.body.querySelectorAll<HTMLElement>('[role="menuitemradio"]');
+    expect(after[0].getAttribute("aria-checked")).toBe("false");
+    expect(after[1].getAttribute("aria-checked")).toBe("true");
+
+    wrapper.unmount();
+  });
+});
+
+describe("CuiDropdownSub", () => {
+  it("renders a submenu trigger and opens the nested menu on click", async () => {
+    const Host = defineComponent({
+      components: {
+        CuiDropdown,
+        CuiDropdownTrigger,
+        CuiDropdownMenu,
+        CuiDropdownItem,
+        CuiDropdownSub,
+      },
+      template: `
+        <CuiDropdown>
+          <CuiDropdownTrigger><button>Menu</button></CuiDropdownTrigger>
+          <CuiDropdownMenu>
+            <CuiDropdownSub trigger="click">
+              More
+              <template #menu>
+                <CuiDropdownItem>Nested item</CuiDropdownItem>
+              </template>
+            </CuiDropdownSub>
+          </CuiDropdownMenu>
+        </CuiDropdown>
+      `,
+    });
+    const wrapper = mount(Host, { attachTo: document.body });
+    await openMenu(wrapper);
+
+    const subTrigger = document.body.querySelector<HTMLElement>(
+      '.cui-dropdown-sub__trigger',
+    );
+    expect(subTrigger).not.toBeNull();
+    expect(subTrigger!.getAttribute("aria-haspopup")).toBe("true");
+    expect(subTrigger!.getAttribute("aria-expanded")).toBe("false");
+    expect(document.body.querySelector(".cui-dropdown-sub__menu")).toBeNull();
+
+    subTrigger!.click();
+    await wrapper.vm.$nextTick();
+
+    expect(
+      document.body
+        .querySelector(".cui-dropdown-sub__trigger")!
+        .getAttribute("aria-expanded"),
+    ).toBe("true");
+    const subMenu = document.body.querySelector(".cui-dropdown-sub__menu");
+    expect(subMenu).not.toBeNull();
+    expect(subMenu!.textContent).toContain("Nested item");
+
+    wrapper.unmount();
+  });
+});
+
+describe("CuiDropdownDivider + CuiDropdownHeader", () => {
+  it("renders the header and divider inside the open menu", async () => {
+    const Host = defineComponent({
+      components: {
+        CuiDropdown,
+        CuiDropdownTrigger,
+        CuiDropdownMenu,
+        CuiDropdownItem,
+        CuiDropdownDivider,
+        CuiDropdownHeader,
+      },
+      template: `
+        <CuiDropdown>
+          <CuiDropdownTrigger><button>Menu</button></CuiDropdownTrigger>
+          <CuiDropdownMenu>
+            <CuiDropdownHeader>Account</CuiDropdownHeader>
+            <CuiDropdownItem>Profile</CuiDropdownItem>
+            <CuiDropdownDivider />
+            <CuiDropdownItem>Sign out</CuiDropdownItem>
+          </CuiDropdownMenu>
+        </CuiDropdown>
+      `,
+    });
+    const wrapper = mount(Host, { attachTo: document.body });
+    await openMenu(wrapper);
+
+    const header = document.body.querySelector(".cui-dropdown-header");
+    expect(header).not.toBeNull();
+    expect(header!.textContent).toContain("Account");
+    expect(header!.getAttribute("role")).toBe("presentation");
+
+    const divider = document.body.querySelector(".cui-dropdown-divider");
+    expect(divider).not.toBeNull();
+    expect(divider!.getAttribute("role")).toBe("separator");
 
     wrapper.unmount();
   });

--- a/packages/clean-ui/src/components/__tests__/CuiDropdown.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiDropdown.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { h } from "vue";
+import CuiDropdown from "../CuiDropdown.vue";
+import CuiDropdownTrigger from "../CuiDropdownTrigger.vue";
+import CuiDropdownMenu from "../CuiDropdownMenu.vue";
+import CuiDropdownItem from "../CuiDropdownItem.vue";
+
+// The menu teleports to document.body and renders only while open (or closing).
+const menuInBody = () => document.body.querySelector(".cui-dropdown-menu");
+
+function mountDropdown(itemProps: Record<string, unknown> = {}, onSelect?: () => void) {
+  return mount(CuiDropdown, {
+    attachTo: document.body,
+    slots: {
+      default: () => [
+        h(CuiDropdownTrigger, () => h("button", "Menu")),
+        h(CuiDropdownMenu, () => [
+          h(CuiDropdownItem, { ...itemProps, onSelect }, () => "Item One"),
+        ]),
+      ],
+    },
+  });
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("CuiDropdown behavior", () => {
+  it("does not render the menu until the trigger is clicked", async () => {
+    const wrapper = mountDropdown();
+    expect(menuInBody()).toBeNull();
+
+    await wrapper.find(".cui-dropdown-trigger").trigger("click");
+    expect(menuInBody()).not.toBeNull();
+    expect(menuInBody()?.textContent).toContain("Item One");
+
+    wrapper.unmount();
+  });
+
+  it("toggles closed when the trigger is clicked again", async () => {
+    vi.useFakeTimers();
+    const wrapper = mountDropdown();
+    const trigger = wrapper.find(".cui-dropdown-trigger");
+
+    await trigger.trigger("click");
+    expect(menuInBody()).not.toBeNull();
+
+    // Second click starts the close animation; advance past the 150ms timer.
+    await trigger.trigger("click");
+    vi.advanceTimersByTime(200);
+    await wrapper.vm.$nextTick();
+    expect(menuInBody()).toBeNull();
+
+    vi.useRealTimers();
+    wrapper.unmount();
+  });
+
+  it("fires @select and closes when an item is clicked", async () => {
+    vi.useFakeTimers();
+    const onSelect = vi.fn();
+    const wrapper = mountDropdown({}, onSelect);
+
+    await wrapper.find(".cui-dropdown-trigger").trigger("click");
+    const item = menuInBody()?.querySelector<HTMLElement>('[role="menuitem"]');
+    expect(item).not.toBeNull();
+
+    item!.click();
+    expect(onSelect).toHaveBeenCalledTimes(1);
+
+    // closeOnSelect defaults true -> closeAll() -> isClosing -> 150ms timer.
+    vi.advanceTimersByTime(200);
+    await wrapper.vm.$nextTick();
+    expect(menuInBody()).toBeNull();
+
+    vi.useRealTimers();
+    wrapper.unmount();
+  });
+
+  it("does not close on select when closeOnSelect is false", async () => {
+    vi.useFakeTimers();
+    const onSelect = vi.fn();
+    const wrapper = mountDropdown({ closeOnSelect: false }, onSelect);
+
+    await wrapper.find(".cui-dropdown-trigger").trigger("click");
+    const item = menuInBody()?.querySelector<HTMLElement>('[role="menuitem"]');
+    item!.click();
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(200);
+    await wrapper.vm.$nextTick();
+    expect(menuInBody()).not.toBeNull();
+
+    vi.useRealTimers();
+    wrapper.unmount();
+  });
+
+  it("does not fire @select for a disabled item", async () => {
+    const onSelect = vi.fn();
+    const wrapper = mountDropdown({ disabled: true }, onSelect);
+
+    await wrapper.find(".cui-dropdown-trigger").trigger("click");
+    const item = menuInBody()?.querySelector<HTMLElement>('[role="menuitem"]');
+    item!.click();
+
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(menuInBody()).not.toBeNull();
+
+    wrapper.unmount();
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiForm.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiForm.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import { h } from "vue";
+import CuiForm from "../CuiForm.vue";
+import CuiFormField from "../CuiFormField.vue";
+import CuiInput from "../CuiInput.vue";
+
+// A small fixture: a CuiForm wrapping a name-bound CuiFormField + CuiInput.
+// The field's v-slot bindings (v-bind="f") wire v-model + error to the form.
+function mountForm(resolver?: (values: Record<string, unknown>) => Record<string, string>) {
+  return mount(CuiForm, {
+    props: { resolver, modelValue: { email: "" } },
+    slots: {
+      default: () =>
+        h(
+          CuiFormField,
+          { name: "email", label: "Email" },
+          { default: (f: Record<string, unknown>) => h(CuiInput, f) },
+        ),
+    },
+  });
+}
+
+describe("CuiForm behavior", () => {
+  it("field binding via v-slot writes the typed value into the form values", async () => {
+    const wrapper = mountForm();
+    await wrapper.find("input").setValue("hi@example.com");
+
+    const updates = wrapper.emitted("update:modelValue") as Array<[Record<string, unknown>]>;
+    expect(updates).toBeTruthy();
+    expect(updates[updates.length - 1][0]).toEqual({ email: "hi@example.com" });
+  });
+
+  it("submit with a passing resolver emits submit with the current values", async () => {
+    const wrapper = mountForm(() => ({}));
+    await wrapper.find("input").setValue("hi@example.com");
+    await wrapper.find("form").trigger("submit");
+    await wrapper.vm.$nextTick();
+
+    const submit = wrapper.emitted("submit") as Array<[Record<string, unknown>]>;
+    expect(submit).toHaveLength(1);
+    expect(submit[0][0]).toEqual({ email: "hi@example.com" });
+    expect(wrapper.emitted("submit-invalid")).toBeUndefined();
+  });
+
+  it("submit with a failing resolver emits submit-invalid and populates errors", async () => {
+    const wrapper = mountForm(() => ({ email: "Required" }));
+    await wrapper.find("form").trigger("submit");
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted("submit")).toBeUndefined();
+    const invalid = wrapper.emitted("submit-invalid") as Array<[Record<string, string>]>;
+    expect(invalid).toHaveLength(1);
+    expect(invalid[0][0]).toEqual({ email: "Required" });
+  });
+
+  it("a failing resolver renders the field's error message through CuiFormField", async () => {
+    const wrapper = mountForm(() => ({ email: "Required" }));
+    await wrapper.find("form").trigger("submit");
+    await wrapper.vm.$nextTick();
+
+    const errEl = wrapper.find(".cui-form-field__error");
+    expect(errEl.exists()).toBe(true);
+    expect(errEl.text()).toBe("Required");
+    expect(wrapper.find(".cui-form-field--error").exists()).toBe(true);
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiInput.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiInput.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import CuiInput from "../CuiInput.vue";
+
+describe("CuiInput", () => {
+  it("emits update:modelValue on input (v-model round-trip)", async () => {
+    const wrapper = mount(CuiInput, { props: { modelValue: "" } });
+    const input = wrapper.get("input.cui-input__native");
+    await input.setValue("hello");
+    expect(wrapper.emitted("update:modelValue")?.at(-1)).toEqual(["hello"]);
+  });
+
+  it("reflects modelValue into the native input value", () => {
+    const wrapper = mount(CuiInput, { props: { modelValue: "preset" } });
+    expect((wrapper.get("input.cui-input__native").element as HTMLInputElement).value).toBe("preset");
+  });
+
+  it("clearable shows a clear button that emits clear and empties the value", async () => {
+    const wrapper = mount(CuiInput, { props: { modelValue: "stuff", clearable: true } });
+    const clearBtn = wrapper.get("button.cui-input__clear");
+    await clearBtn.trigger("click");
+    expect(wrapper.emitted("clear")).toHaveLength(1);
+    expect(wrapper.emitted("update:modelValue")?.at(-1)).toEqual([""]);
+  });
+
+  it("does not show the clear button when there is no value", () => {
+    const wrapper = mount(CuiInput, { props: { modelValue: "", clearable: true } });
+    expect(wrapper.find("button.cui-input__clear").exists()).toBe(false);
+  });
+
+  it("password type renders a toggle that switches the input type", async () => {
+    const wrapper = mount(CuiInput, { props: { type: "password", modelValue: "secret" } });
+    const native = wrapper.get("input.cui-input__native");
+    expect(native.attributes("type")).toBe("password");
+    await wrapper.get("button.cui-input__password-toggle").trigger("click");
+    expect(wrapper.get("input.cui-input__native").attributes("type")).toBe("text");
+  });
+
+  it("renders the error message and sets aria-invalid when error is set", () => {
+    const wrapper = mount(CuiInput, {
+      props: { error: true, errorMessage: "Required field" },
+    });
+    expect(wrapper.get(".cui-input__error").text()).toBe("Required field");
+    expect(wrapper.get("input.cui-input__native").attributes("aria-invalid")).toBe("true");
+  });
+
+  it("passes disabled and readonly through to the native input", () => {
+    const disabled = mount(CuiInput, { props: { disabled: true } });
+    expect(disabled.get("input.cui-input__native").attributes("disabled")).toBeDefined();
+
+    const readonly = mount(CuiInput, { props: { readonly: true } });
+    expect(readonly.get("input.cui-input__native").attributes("readonly")).toBeDefined();
+  });
+
+  it("hides the clear button when disabled even with a value", () => {
+    const wrapper = mount(CuiInput, {
+      props: { modelValue: "stuff", clearable: true, disabled: true },
+    });
+    expect(wrapper.find("button.cui-input__clear").exists()).toBe(false);
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiInputStepper.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiInputStepper.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import CuiInputStepper from "../CuiInputStepper.vue";
+
+// In horizontal layout the buttons render in DOM order: [decrement, increment].
+function buttons(wrapper: ReturnType<typeof mount>) {
+  const all = wrapper.findAll("button");
+  return { dec: all[0], inc: all[1] };
+}
+
+describe("CuiInputStepper", () => {
+  it("increment adds step to the model value", async () => {
+    const wrapper = mount(CuiInputStepper, { props: { modelValue: 5, step: 2 } });
+    await buttons(wrapper).inc.trigger("click");
+    expect(wrapper.emitted("update:modelValue")?.[0]).toEqual([7]);
+  });
+
+  it("decrement subtracts step from the model value", async () => {
+    const wrapper = mount(CuiInputStepper, { props: { modelValue: 5, step: 2 } });
+    await buttons(wrapper).dec.trigger("click");
+    expect(wrapper.emitted("update:modelValue")?.[0]).toEqual([3]);
+  });
+
+  it("does not increment past max", async () => {
+    const wrapper = mount(CuiInputStepper, { props: { modelValue: 10, max: 10, step: 1 } });
+    const { inc } = buttons(wrapper);
+    expect(inc.attributes("disabled")).toBeDefined();
+    await inc.trigger("click");
+    expect(wrapper.emitted("update:modelValue")).toBeUndefined();
+  });
+
+  it("does not decrement below min", async () => {
+    const wrapper = mount(CuiInputStepper, { props: { modelValue: 0, min: 0, step: 1 } });
+    const { dec } = buttons(wrapper);
+    expect(dec.attributes("disabled")).toBeDefined();
+    await dec.trigger("click");
+    expect(wrapper.emitted("update:modelValue")).toBeUndefined();
+  });
+
+  it("wrap rolls increment from max back to min", async () => {
+    const wrapper = mount(CuiInputStepper, { props: { modelValue: 5, min: 1, max: 5, step: 1, wrap: true } });
+    await buttons(wrapper).inc.trigger("click");
+    expect(wrapper.emitted("update:modelValue")?.[0]).toEqual([1]);
+  });
+
+  it("disabled blocks both increment and decrement", async () => {
+    const wrapper = mount(CuiInputStepper, { props: { modelValue: 5, disabled: true } });
+    const { dec, inc } = buttons(wrapper);
+    await inc.trigger("click");
+    await dec.trigger("click");
+    expect(wrapper.emitted("update:modelValue")).toBeUndefined();
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiMaskedInput.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiMaskedInput.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import CuiMaskedInput from "../CuiMaskedInput.vue";
+
+// The component intercepts native `beforeinput` events, calls preventDefault,
+// and manually rebuilds the masked value from the raw token characters. To
+// exercise that path we dispatch real InputEvents on the inner <input>, the
+// same way a browser would (with inputType + data). After each keystroke the
+// component repositions the caret on nextTick, so we await it and type the
+// next char at the resulting caret position. This mirrors real typing.
+async function typeSequence(
+  wrapper: ReturnType<typeof mount>,
+  input: HTMLInputElement,
+  text: string,
+) {
+  // Start at the first slot; the component repositions the caret after each
+  // keystroke, so subsequent chars insert at the live caret position.
+  input.setSelectionRange(0, 0);
+  for (const char of text) {
+    input.dispatchEvent(
+      new InputEvent("beforeinput", {
+        inputType: "insertText",
+        data: char,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    await wrapper.vm.$nextTick();
+  }
+}
+
+describe("CuiMaskedInput", () => {
+  it("formats raw modelValue through the mask on display", () => {
+    const wrapper = mount(CuiMaskedInput, {
+      props: { mask: "(###) ###-####", modelValue: "1234567890" },
+    });
+    const input = wrapper.find("input").element as HTMLInputElement;
+    expect(input.value).toBe("(123) 456-7890");
+  });
+
+  it("fills unfilled token slots with fillChar", () => {
+    const wrapper = mount(CuiMaskedInput, {
+      props: { mask: "###-##", modelValue: "12" },
+    });
+    const input = wrapper.find("input").element as HTMLInputElement;
+    expect(input.value).toBe("12_-__");
+  });
+
+  it("applies the mask to typed input and emits the raw value", async () => {
+    const wrapper = mount(CuiMaskedInput, {
+      props: { mask: "###-###", modelValue: "" },
+      attachTo: document.body,
+    });
+    const input = wrapper.find("input").element as HTMLInputElement;
+
+    await typeSequence(wrapper, input, "1234");
+
+    // Raw value is digits only; formatted inserts the literal separator.
+    const raw = wrapper.emitted("update:modelValue")!.at(-1)![0];
+    expect(raw).toBe("1234");
+    expect(wrapper.find("input").element.value).toBe("123-4__");
+
+    wrapper.unmount();
+  });
+
+  it("rejects characters that do not match the token pattern", async () => {
+    const wrapper = mount(CuiMaskedInput, {
+      props: { mask: "###", modelValue: "" },
+      attachTo: document.body,
+    });
+    const input = wrapper.find("input").element as HTMLInputElement;
+
+    await typeSequence(wrapper, input, "a"); // letter into a digit-only mask
+
+    // No emit at all because the filtered insert is empty.
+    expect(wrapper.emitted("update:modelValue")).toBeUndefined();
+    expect(wrapper.find("input").element.value).toBe("___");
+
+    wrapper.unmount();
+  });
+
+  it("emits both raw modelValue and the formatted value", async () => {
+    const wrapper = mount(CuiMaskedInput, {
+      props: { mask: "##/##", modelValue: "" },
+      attachTo: document.body,
+    });
+    const input = wrapper.find("input").element as HTMLInputElement;
+
+    await typeSequence(wrapper, input, "123");
+
+    expect(wrapper.emitted("update:modelValue")!.at(-1)![0]).toBe("123");
+    expect(wrapper.emitted("update:formattedValue")!.at(-1)![0]).toBe("12/3_");
+
+    wrapper.unmount();
+  });
+
+  it("treats backslash-escaped mask characters as literals, not tokens", () => {
+    // \# is a literal '#'; the following # is a digit token.
+    const wrapper = mount(CuiMaskedInput, {
+      props: { mask: "\\##", modelValue: "5" },
+    });
+    const input = wrapper.find("input").element as HTMLInputElement;
+    expect(input.value).toBe("#5");
+  });
+
+  it("supports custom token definitions", () => {
+    const wrapper = mount(CuiMaskedInput, {
+      props: {
+        mask: "XX",
+        tokens: { X: { pattern: /[0-9a-fA-F]/ } },
+        modelValue: "aF",
+      },
+    });
+    const input = wrapper.find("input").element as HTMLInputElement;
+    expect(input.value).toBe("aF");
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiModal.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiModal.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import CuiModal from "../CuiModal.vue";
+
+// The overlay close path defers update:visible behind a 200ms exit animation,
+// so the whole suite runs on fake timers for determinism.
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  document.body.style.overflow = "";
+});
+
+describe("CuiModal", () => {
+  it("does not render the dialog when visible is false", () => {
+    const wrapper = mount(CuiModal, { props: { visible: false } });
+    expect(document.body.querySelector(".cui-modal")).toBeNull();
+    wrapper.unmount();
+  });
+
+  it("renders the teleported dialog with the title when visible", async () => {
+    const wrapper = mount(CuiModal, {
+      props: { visible: true, title: "Confirm action" },
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    const dialog = document.body.querySelector('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+    expect(dialog?.getAttribute("aria-modal")).toBe("true");
+    expect(document.body.textContent).toContain("Confirm action");
+    wrapper.unmount();
+  });
+
+  it("toggling visible to false emits update:visible=false after the exit animation", async () => {
+    const wrapper = mount(CuiModal, { props: { visible: true } });
+    await vi.runOnlyPendingTimersAsync();
+    expect(document.body.querySelector(".cui-modal")).not.toBeNull();
+
+    await wrapper.setProps({ visible: false });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(wrapper.emitted("update:visible")?.at(-1)).toEqual([false]);
+    expect(document.body.querySelector(".cui-modal")).toBeNull();
+    wrapper.unmount();
+  });
+
+  it("clicking the header close button requests close (update:visible=false + close)", async () => {
+    const wrapper = mount(CuiModal, { props: { visible: true, title: "Hi" } });
+    await vi.runOnlyPendingTimersAsync();
+
+    const closeBtn = document.body.querySelector<HTMLButtonElement>(
+      ".cui-modal-overlay button",
+    );
+    expect(closeBtn).not.toBeNull();
+    closeBtn!.click();
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(wrapper.emitted("update:visible")?.at(-1)).toEqual([false]);
+    expect(wrapper.emitted("close")).toBeTruthy();
+    wrapper.unmount();
+  });
+
+  it("clicking the backdrop emits update:visible=false", async () => {
+    const wrapper = mount(CuiModal, { props: { visible: true } });
+    await vi.runOnlyPendingTimersAsync();
+
+    const backdrop = document.body.querySelector<HTMLElement>(".cui-backdrop");
+    expect(backdrop).not.toBeNull();
+    backdrop!.click();
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(wrapper.emitted("update:visible")?.at(-1)).toEqual([false]);
+    wrapper.unmount();
+  });
+
+  it("pressing Escape emits update:visible=false", async () => {
+    const wrapper = mount(CuiModal, { props: { visible: true } });
+    await vi.runOnlyPendingTimersAsync();
+
+    const overlay = document.body.querySelector<HTMLElement>(".cui-modal-overlay");
+    expect(overlay).not.toBeNull();
+    overlay!.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(wrapper.emitted("update:visible")?.at(-1)).toEqual([false]);
+    wrapper.unmount();
+  });
+
+  it("persistent blocks Escape and backdrop close", async () => {
+    const wrapper = mount(CuiModal, { props: { visible: true, persistent: true } });
+    await vi.runOnlyPendingTimersAsync();
+
+    document.body
+      .querySelector<HTMLElement>(".cui-modal-overlay")!
+      .dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    document.body.querySelector<HTMLElement>(".cui-backdrop")!.click();
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(wrapper.emitted("update:visible")).toBeFalsy();
+    expect(document.body.querySelector(".cui-modal")).not.toBeNull();
+    wrapper.unmount();
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiPagination.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiPagination.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import CuiPagination from "../CuiPagination.vue";
+
+// totalItems=50, perPage=10 -> 5 pages. We drive pages via totalPages directly
+// for the page-button cases, and via total/perPage for the info/derivation case.
+
+describe("CuiPagination", () => {
+  it("emits update:currentPage with the next page when Next is clicked", async () => {
+    const wrapper = mount(CuiPagination, {
+      props: { currentPage: 2, totalPages: 5 },
+    });
+    await wrapper.find('[aria-label="Next page"]').trigger("click");
+    expect(wrapper.emitted("update:currentPage")).toEqual([[3]]);
+  });
+
+  it("emits update:currentPage with the previous page when Prev is clicked", async () => {
+    const wrapper = mount(CuiPagination, {
+      props: { currentPage: 2, totalPages: 5 },
+    });
+    await wrapper.find('[aria-label="Previous page"]').trigger("click");
+    expect(wrapper.emitted("update:currentPage")).toEqual([[1]]);
+  });
+
+  it("emits the page number when a page button is clicked", async () => {
+    const wrapper = mount(CuiPagination, {
+      props: { currentPage: 1, totalPages: 5 },
+    });
+    await wrapper.find('[aria-label="Page 4"]').trigger("click");
+    expect(wrapper.emitted("update:currentPage")).toEqual([[4]]);
+  });
+
+  it("does not emit when clicking the already-current page", async () => {
+    const wrapper = mount(CuiPagination, {
+      props: { currentPage: 3, totalPages: 5 },
+    });
+    await wrapper.find('[aria-label="Page 3"]').trigger("click");
+    expect(wrapper.emitted("update:currentPage")).toBeUndefined();
+  });
+
+  it("disables Previous at the first page and Next at the last page", () => {
+    const first = mount(CuiPagination, { props: { currentPage: 1, totalPages: 5 } });
+    expect(first.find('[aria-label="Previous page"]').attributes("disabled")).toBeDefined();
+    expect(first.find('[aria-label="Next page"]').attributes("disabled")).toBeUndefined();
+
+    const last = mount(CuiPagination, { props: { currentPage: 5, totalPages: 5 } });
+    expect(last.find('[aria-label="Next page"]').attributes("disabled")).toBeDefined();
+    expect(last.find('[aria-label="Previous page"]').attributes("disabled")).toBeUndefined();
+  });
+
+  it("does not emit when clicking a disabled bound control", async () => {
+    const wrapper = mount(CuiPagination, { props: { currentPage: 1, totalPages: 5 } });
+    await wrapper.find('[aria-label="Previous page"]').trigger("click");
+    expect(wrapper.emitted("update:currentPage")).toBeUndefined();
+  });
+
+  it("derives page count from total and perPage (50/10 -> 5 page buttons)", () => {
+    const wrapper = mount(CuiPagination, {
+      props: { currentPage: 1, total: 50, perPage: 10, totalPages: 5 },
+    });
+    for (const p of [1, 2, 3, 4, 5]) {
+      expect(wrapper.find(`[aria-label="Page ${p}"]`).exists()).toBe(true);
+    }
+    expect(wrapper.find('[aria-label="Page 6"]').exists()).toBe(false);
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiPopover.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiPopover.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import CuiPopover from "../CuiPopover.vue";
+
+// The popover panel teleports to <body> and renders only while open
+// (v-if="isVisible"). It carries role="dialog", so we can locate it there.
+const panel = () => document.body.querySelector('[role="dialog"]');
+
+describe("CuiPopover behavior", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.querySelectorAll('[role="dialog"]').forEach((el) => el.remove());
+  });
+
+  it("clicking the trigger (default trigger='click') opens the panel", async () => {
+    const wrapper = mount(CuiPopover, {
+      attachTo: document.body,
+      slots: { default: "<button>Open</button>", content: "Panel body" },
+    });
+
+    expect(panel()).toBeNull();
+
+    await wrapper.trigger("click");
+
+    const p = panel();
+    expect(p).not.toBeNull();
+    expect(p?.textContent).toContain("Panel body");
+
+    wrapper.unmount();
+  });
+
+  it("clicking the trigger again closes it (after hideDelay)", async () => {
+    vi.useFakeTimers();
+    const wrapper = mount(CuiPopover, {
+      attachTo: document.body,
+      props: { hideDelay: 100 },
+      slots: { default: "<button>Open</button>", content: "Body" },
+    });
+
+    await wrapper.trigger("click");
+    expect(panel()).not.toBeNull();
+
+    // Second click triggers doHide(), which is deferred by hideDelay.
+    await wrapper.trigger("click");
+    expect(panel()).not.toBeNull(); // still open before the timer fires
+
+    vi.advanceTimersByTime(100);
+    await wrapper.vm.$nextTick();
+    expect(panel()).toBeNull();
+
+    wrapper.unmount();
+  });
+
+  it("respects controlled v-model:visible", async () => {
+    const wrapper = mount(CuiPopover, {
+      attachTo: document.body,
+      props: { visible: false },
+      slots: { default: "<button>Open</button>", content: "Body" },
+    });
+
+    expect(panel()).toBeNull();
+
+    await wrapper.setProps({ visible: true });
+    expect(panel()).not.toBeNull();
+
+    await wrapper.setProps({ visible: false });
+    expect(panel()).toBeNull();
+
+    wrapper.unmount();
+  });
+
+  it("emits update:visible when opened by a click", async () => {
+    const wrapper = mount(CuiPopover, {
+      attachTo: document.body,
+      slots: { default: "<button>Open</button>", content: "Body" },
+    });
+
+    await wrapper.trigger("click");
+
+    expect(wrapper.emitted("update:visible")).toBeTruthy();
+    expect(wrapper.emitted("update:visible")![0]).toEqual([true]);
+
+    wrapper.unmount();
+  });
+
+  it("the header close button hides the panel", async () => {
+    vi.useFakeTimers();
+    const wrapper = mount(CuiPopover, {
+      attachTo: document.body,
+      props: { title: "Heading", hideDelay: 0 },
+      slots: { content: "Body" },
+    });
+
+    // Open via the default click trigger.
+    await wrapper.trigger("click");
+    const p = panel();
+    expect(p).not.toBeNull();
+
+    const closeBtn = p!.querySelector("button");
+    expect(closeBtn).not.toBeNull();
+    closeBtn!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await wrapper.vm.$nextTick();
+
+    expect(panel()).toBeNull();
+
+    wrapper.unmount();
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiRadioGroup.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiRadioGroup.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import { h } from "vue";
+import CuiRadioGroup from "../CuiRadioGroup.vue";
+import CuiRadio from "../CuiRadio.vue";
+
+function mountGroup(props: Record<string, unknown> = {}) {
+  return mount(CuiRadioGroup, {
+    props,
+    slots: {
+      default: () => [
+        h(CuiRadio, { value: "a", label: "Apple" }),
+        h(CuiRadio, { value: "b", label: "Banana" }),
+        h(CuiRadio, { value: "c", label: "Cherry" }),
+      ],
+    },
+  });
+}
+
+describe("CuiRadioGroup", () => {
+  it("reflects the group modelValue as the checked child", () => {
+    const wrapper = mountGroup({ modelValue: "b" });
+    const radios = wrapper.findAllComponents(CuiRadio);
+    expect(radios[0].find('[role="radio"]').attributes("aria-checked")).toBe("false");
+    expect(radios[1].find('[role="radio"]').attributes("aria-checked")).toBe("true");
+    expect(radios[2].find('[role="radio"]').attributes("aria-checked")).toBe("false");
+  });
+
+  it("emits update:modelValue with the clicked radio's value", async () => {
+    const wrapper = mountGroup({ modelValue: "a" });
+    const radios = wrapper.findAllComponents(CuiRadio);
+    await radios[2].find('[role="radio"]').trigger("click");
+    expect(wrapper.emitted("update:modelValue")).toBeTruthy();
+    expect(wrapper.emitted("update:modelValue")![0]).toEqual(["c"]);
+  });
+
+  it("selecting a new radio deselects the previously selected one", async () => {
+    const wrapper = mountGroup({ modelValue: "a" });
+    await wrapper.find('[role="radio"]'); // ensure rendered
+    const radios = wrapper.findAllComponents(CuiRadio);
+
+    await radios[1].find('[role="radio"]').trigger("click");
+    // parent owns the value; emulate v-model by writing the prop back
+    await wrapper.setProps({ modelValue: wrapper.emitted("update:modelValue")!.at(-1)![0] });
+
+    expect(radios[0].find('[role="radio"]').attributes("aria-checked")).toBe("false");
+    expect(radios[1].find('[role="radio"]').attributes("aria-checked")).toBe("true");
+    expect(radios[2].find('[role="radio"]').attributes("aria-checked")).toBe("false");
+  });
+
+  it("does not emit when the group is disabled", async () => {
+    const wrapper = mountGroup({ modelValue: "a", disabled: true });
+    const radios = wrapper.findAllComponents(CuiRadio);
+    await radios[1].find('[role="radio"]').trigger("click");
+    expect(wrapper.emitted("update:modelValue")).toBeFalsy();
+  });
+
+  it("renders children as buttons when variant='buttons'", () => {
+    const wrapper = mountGroup({ modelValue: "a", variant: "buttons" });
+    const buttons = wrapper.findAll("button.cui-radio-button");
+    // button variant renders <button> elements (not <label>) inside a button group
+    expect(buttons).toHaveLength(3);
+    expect(buttons[0].attributes("role")).toBe("radio");
+    expect(buttons[0].classes()).toContain("cui-radio-button--active");
+    expect(buttons[1].classes()).not.toContain("cui-radio-button--active");
+    expect(wrapper.find(".cui-radio-group--buttons").exists()).toBe(true);
+  });
+
+  it("button variant still drives selection through the group", async () => {
+    const wrapper = mountGroup({ modelValue: "a", variant: "buttons" });
+    const buttons = wrapper.findAll("button.cui-radio-button");
+    await buttons[2].trigger("click");
+    expect(wrapper.emitted("update:modelValue")![0]).toEqual(["c"]);
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiRating.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiRating.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import CuiRating from "../CuiRating.vue";
+
+// The star wrappers are the clickable <div>s inside the inline-flex row.
+// They each contain a CuiIcon. We select them by the click handler region:
+// every star div has `cursor` in its inline style, so query the icon-bearing divs.
+function stars(wrapper: ReturnType<typeof mount>) {
+  return wrapper.findAll("div[style*='cursor']");
+}
+
+describe("CuiRating", () => {
+  it("renders `max` clickable stars (default 5)", () => {
+    const wrapper = mount(CuiRating);
+    expect(stars(wrapper)).toHaveLength(5);
+  });
+
+  it("honors a custom `max`", () => {
+    const wrapper = mount(CuiRating, { props: { max: 8 } });
+    expect(stars(wrapper)).toHaveLength(8);
+  });
+
+  it("emits update:modelValue with the clicked star index", async () => {
+    const wrapper = mount(CuiRating, { props: { modelValue: 0 } });
+    await stars(wrapper)[2].trigger("click");
+    expect(wrapper.emitted("update:modelValue")).toEqual([[3]]);
+  });
+
+  it("clears to 0 when clicking the current value (clearable default)", async () => {
+    const wrapper = mount(CuiRating, { props: { modelValue: 3 } });
+    await stars(wrapper)[2].trigger("click");
+    expect(wrapper.emitted("update:modelValue")).toEqual([[0]]);
+  });
+
+  it("does not clear when clearable is false", async () => {
+    const wrapper = mount(CuiRating, { props: { modelValue: 3, clearable: false } });
+    await stars(wrapper)[2].trigger("click");
+    expect(wrapper.emitted("update:modelValue")).toEqual([[3]]);
+  });
+
+  it("readonly prevents emitting on click", async () => {
+    const wrapper = mount(CuiRating, { props: { modelValue: 2, readonly: true } });
+    await stars(wrapper)[4].trigger("click");
+    expect(wrapper.emitted("update:modelValue")).toBeUndefined();
+  });
+
+  it("disabled prevents emitting on click", async () => {
+    const wrapper = mount(CuiRating, { props: { modelValue: 2, disabled: true } });
+    await stars(wrapper)[4].trigger("click");
+    expect(wrapper.emitted("update:modelValue")).toBeUndefined();
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiSelect.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiSelect.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import CuiSelect from "../CuiSelect.vue";
+
+const OPTIONS = [
+  { value: "a", label: "Apple" },
+  { value: "b", label: "Banana" },
+  { value: "c", label: "Cherry" },
+];
+
+function bodyOptions() {
+  return Array.from(
+    document.querySelectorAll(".cui-select__dropdown .cui-select__option"),
+  ) as HTMLElement[];
+}
+
+describe("CuiSelect behavior", () => {
+  it("opens the listbox on trigger click", async () => {
+    const wrapper = mount(CuiSelect, {
+      props: { options: OPTIONS },
+      attachTo: document.body,
+    });
+
+    // Closed initially: no dropdown teleported, combobox not expanded.
+    expect(document.querySelector(".cui-select__dropdown")).toBeNull();
+    expect(wrapper.get('[role="combobox"]').attributes("aria-expanded")).toBe("false");
+
+    await wrapper.get('[role="combobox"]').trigger("click");
+
+    expect(document.querySelector(".cui-select__dropdown")).not.toBeNull();
+    expect(wrapper.get('[role="combobox"]').attributes("aria-expanded")).toBe("true");
+    expect(bodyOptions()).toHaveLength(3);
+
+    wrapper.unmount();
+  });
+
+  it("selecting an option emits the value and closes (single)", async () => {
+    const wrapper = mount(CuiSelect, {
+      props: { options: OPTIONS },
+      attachTo: document.body,
+    });
+
+    await wrapper.get('[role="combobox"]').trigger("click");
+    bodyOptions()[1].click();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted("update:modelValue")).toEqual([["b"]]);
+    // Single select closes after choosing.
+    expect(document.querySelector(".cui-select__dropdown")).toBeNull();
+
+    wrapper.unmount();
+  });
+
+  it("multiple accumulates an array and stays open", async () => {
+    const wrapper = mount(CuiSelect, {
+      props: { options: OPTIONS, multiple: true, modelValue: [] },
+      attachTo: document.body,
+    });
+
+    await wrapper.get('[role="combobox"]').trigger("click");
+
+    bodyOptions()[0].click();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted("update:modelValue")!.at(-1)).toEqual([["a"]]);
+    // Stays open in multiple mode.
+    expect(document.querySelector(".cui-select__dropdown")).not.toBeNull();
+
+    // Simulate the parent committing the first selection, then pick a second.
+    await wrapper.setProps({ modelValue: ["a"] });
+    bodyOptions()[2].click();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted("update:modelValue")!.at(-1)).toEqual([["a", "c"]]);
+
+    wrapper.unmount();
+  });
+
+  it("clearable emits null to clear the value", async () => {
+    const wrapper = mount(CuiSelect, {
+      props: { options: OPTIONS, clearable: true, modelValue: "a" },
+      attachTo: document.body,
+    });
+
+    const clearBtn = wrapper.get(".cui-select__clear");
+    await clearBtn.trigger("click");
+
+    expect(wrapper.emitted("update:modelValue")).toEqual([[null]]);
+
+    wrapper.unmount();
+  });
+
+  it("shows the placeholder when empty and the label when a value is set", async () => {
+    const wrapper = mount(CuiSelect, {
+      props: { options: OPTIONS, placeholder: "Pick a fruit" },
+      attachTo: document.body,
+    });
+
+    expect(wrapper.get(".cui-select__placeholder").text()).toBe("Pick a fruit");
+    expect(wrapper.find(".cui-select__label").exists()).toBe(false);
+
+    await wrapper.setProps({ modelValue: "c" });
+
+    expect(wrapper.find(".cui-select__placeholder").exists()).toBe(false);
+    expect(wrapper.get(".cui-select__label").text()).toBe("Cherry");
+
+    wrapper.unmount();
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiSlideover.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiSlideover.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import CuiSlideover from "../CuiSlideover.vue";
+
+// useOverlay closes via setTimeout(animationDuration=250) before emitting
+// update:visible=false, so timers must be faked for deterministic close assertions.
+describe("CuiSlideover", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.style.overflow = "";
+  });
+
+  it("does not render the dialog while visible=false", () => {
+    const wrapper = mount(CuiSlideover, { props: { visible: false } });
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull();
+    wrapper.unmount();
+  });
+
+  it("teleports a dialog into document.body when opened via v-model:visible", async () => {
+    const wrapper = mount(CuiSlideover, {
+      props: { visible: false, title: "Settings" },
+    });
+
+    await wrapper.setProps({ visible: true });
+    await vi.runAllTimersAsync();
+
+    const dialog = document.body.querySelector('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+    expect(dialog?.getAttribute("aria-modal")).toBe("true");
+    // Title prop renders into the teleported header.
+    expect(document.body.textContent).toContain("Settings");
+
+    wrapper.unmount();
+  });
+
+  it("closing via v-model emits update:visible=false and removes the dialog after the exit animation", async () => {
+    const wrapper = mount(CuiSlideover, { props: { visible: true } });
+    await vi.runAllTimersAsync();
+    expect(document.body.querySelector('[role="dialog"]')).not.toBeNull();
+
+    await wrapper.setProps({ visible: false });
+    await vi.runAllTimersAsync();
+
+    expect(wrapper.emitted("update:visible")?.at(-1)).toEqual([false]);
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull();
+
+    wrapper.unmount();
+  });
+
+  it("close button emits update:visible=false and close", async () => {
+    const wrapper = mount(CuiSlideover, {
+      props: { visible: true, title: "Panel" },
+    });
+    await vi.runAllTimersAsync();
+
+    const closeBtn = document.body.querySelector<HTMLButtonElement>(
+      '[role="dialog"] button',
+    );
+    expect(closeBtn).not.toBeNull();
+
+    closeBtn!.click();
+    await vi.runAllTimersAsync();
+
+    expect(wrapper.emitted("update:visible")?.at(-1)).toEqual([false]);
+    expect(wrapper.emitted("close")).toHaveLength(1);
+
+    wrapper.unmount();
+  });
+
+  it("persistent backdrop click does not close the slideover", async () => {
+    const wrapper = mount(CuiSlideover, {
+      props: { visible: true, persistent: true },
+    });
+    await vi.runAllTimersAsync();
+
+    const backdrop = document.body.querySelector<HTMLElement>(
+      '[role="dialog"]',
+    )?.parentElement?.firstElementChild as HTMLElement;
+    backdrop?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await vi.runAllTimersAsync();
+
+    expect(wrapper.emitted("update:visible")).toBeUndefined();
+    expect(document.body.querySelector('[role="dialog"]')).not.toBeNull();
+
+    wrapper.unmount();
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiSlider.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiSlider.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import CuiSlider from "../CuiSlider.vue";
+
+describe("CuiSlider", () => {
+  it("renders a native range input reflecting modelValue, min, max, step", () => {
+    const wrapper = mount(CuiSlider, {
+      props: { modelValue: 40, min: 0, max: 100, step: 5 },
+    });
+    const input = wrapper.get("input[type=range]");
+    expect((input.element as HTMLInputElement).value).toBe("40");
+    expect(input.attributes("min")).toBe("0");
+    expect(input.attributes("max")).toBe("100");
+    expect(input.attributes("step")).toBe("5");
+  });
+
+  it("emits update:modelValue with the parsed numeric value on input", async () => {
+    const wrapper = mount(CuiSlider, { props: { modelValue: 10 } });
+    const input = wrapper.get("input[type=range]");
+    (input.element as HTMLInputElement).value = "75";
+    await input.trigger("input");
+
+    const events = wrapper.emitted("update:modelValue");
+    expect(events).toHaveLength(1);
+    expect(events![0]).toEqual([75]);
+    expect(typeof events![0][0]).toBe("number");
+  });
+
+  it("clamps the native input value to max when set above range", async () => {
+    const wrapper = mount(CuiSlider, { props: { modelValue: 0, min: 0, max: 10 } });
+    const input = wrapper.get("input[type=range]");
+    // The native range input clamps its own value to [min,max].
+    (input.element as HTMLInputElement).value = "999";
+    await input.trigger("input");
+
+    const events = wrapper.emitted("update:modelValue");
+    expect(events).toHaveLength(1);
+    expect(events![0]).toEqual([10]);
+  });
+
+  it("clamps the native input value to min when set below range", async () => {
+    const wrapper = mount(CuiSlider, { props: { modelValue: 50, min: 20, max: 80 } });
+    const input = wrapper.get("input[type=range]");
+    (input.element as HTMLInputElement).value = "-5";
+    await input.trigger("input");
+
+    const events = wrapper.emitted("update:modelValue");
+    expect(events![0]).toEqual([20]);
+  });
+
+  it("exposes the step on the native input so it governs keyboard arrow increments", () => {
+    const wrapper = mount(CuiSlider, { props: { modelValue: 0, min: 0, max: 100, step: 10 } });
+    // Arrow-key stepping is delegated to the native range input (not simulated in jsdom).
+    // Verify the contract that drives it: the step attribute is wired through.
+    expect(wrapper.get("input[type=range]").attributes("step")).toBe("10");
+  });
+
+  it("disables the input when disabled", async () => {
+    const wrapper = mount(CuiSlider, { props: { modelValue: 30, disabled: true } });
+    const input = wrapper.get("input[type=range]");
+    expect((input.element as HTMLInputElement).disabled).toBe(true);
+  });
+
+  it("reflects external modelValue updates onto the input", async () => {
+    const wrapper = mount(CuiSlider, { props: { modelValue: 10 } });
+    const input = wrapper.get("input[type=range]");
+    expect((input.element as HTMLInputElement).value).toBe("10");
+
+    await wrapper.setProps({ modelValue: 60 });
+    expect((input.element as HTMLInputElement).value).toBe("60");
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiTable.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiTable.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import { h } from "vue";
+import CuiTable from "../CuiTable.vue";
+import CuiTableHead from "../CuiTableHead.vue";
+import CuiTableBody from "../CuiTableBody.vue";
+import CuiTableFoot from "../CuiTableFoot.vue";
+import CuiTableRow from "../CuiTableRow.vue";
+import CuiTableCell from "../CuiTableCell.vue";
+
+// Build the table tree with render functions (h) rather than an in-DOM string
+// template — the browser HTML parser strips custom tags nested inside <table>,
+// so a string template would never produce real thead/tbody/tr/td/th nodes.
+function mountTable(props: Record<string, unknown> = {}) {
+  return mount(CuiTable, {
+    props,
+    slots: {
+      default: () => [
+        h(CuiTableHead, () => [
+          h(CuiTableRow, () => [
+            h(CuiTableCell, { header: true }, () => "Name"),
+            h(CuiTableCell, { header: true, align: "right" }, () => "Score"),
+          ]),
+        ]),
+        h(CuiTableBody, () => [
+          h(CuiTableRow, () => [
+            h(CuiTableCell, () => "Alice"),
+            h(CuiTableCell, () => "10"),
+          ]),
+          h(CuiTableRow, { selected: true }, () => [
+            h(CuiTableCell, () => "Bob"),
+            h(CuiTableCell, () => "20"),
+          ]),
+        ]),
+        h(CuiTableFoot, () => [
+          h(CuiTableRow, () => [
+            h(CuiTableCell, () => "Total"),
+            h(CuiTableCell, () => "30"),
+          ]),
+        ]),
+      ],
+    },
+  });
+}
+
+describe("CuiTable + sub-components", () => {
+  it("renders real table semantics with every section assembled via context", () => {
+    const wrapper = mountTable();
+
+    expect(wrapper.find("table.cui-table").exists()).toBe(true);
+    expect(wrapper.find("thead").exists()).toBe(true);
+    expect(wrapper.find("tbody").exists()).toBe(true);
+    expect(wrapper.find("tfoot").exists()).toBe(true);
+
+    // thead 1 row + tbody 2 rows + tfoot 1 row = 4 <tr>
+    expect(wrapper.findAll("tr")).toHaveLength(4);
+  });
+
+  it("renders header cells as <th scope=col> in the head and body cells as <td>", () => {
+    const wrapper = mountTable();
+
+    // CuiTableCell with header:true renders <th> and gets scope="col"
+    const headCells = wrapper.findAll("thead th");
+    expect(headCells).toHaveLength(2);
+    expect(headCells.map((c) => c.text())).toEqual(["Name", "Score"]);
+    expect(headCells[0].attributes("scope")).toBe("col");
+
+    // Body cells (no header prop) render as <td>
+    const bodyCells = wrapper.findAll("tbody td");
+    expect(bodyCells).toHaveLength(4);
+    expect(bodyCells[0].text()).toBe("Alice");
+  });
+
+  it("applies the align style on a cell", () => {
+    const wrapper = mountTable();
+    const scoreHeader = wrapper.findAll("thead th")[1];
+    expect(scoreHeader.attributes("style")).toContain("text-align: right");
+  });
+
+  it("marks a selected row with cui-table-row--selected", () => {
+    const wrapper = mountTable();
+    const selected = wrapper.findAll("tr.cui-table-row--selected");
+    expect(selected).toHaveLength(1);
+    expect(selected[0].text()).toContain("Bob");
+  });
+
+  it("applies striped / bordered / hoverable modifier classes from props", () => {
+    const wrapper = mountTable({ striped: true, bordered: true, hoverable: true });
+    const table = wrapper.find("table.cui-table");
+    expect(table.classes()).toContain("cui-table--striped");
+    expect(table.classes()).toContain("cui-table--bordered");
+    expect(table.classes()).toContain("cui-table--hoverable");
+  });
+
+  it("maps the size prop through to a modifier class", () => {
+    const wrapper = mountTable({ size: "lg" });
+    expect(wrapper.find("table.cui-table").classes()).toContain("cui-table--lg");
+  });
+
+  it("wraps the table in a scroll container when maxHeight is set", () => {
+    const wrapper = mountTable({ maxHeight: "200px" });
+    const scroller = wrapper.find(".cui-table-wrapper");
+    expect(scroller.exists()).toBe(true);
+    // the table lives inside the scroll wrapper
+    expect(scroller.find("table.cui-table").exists()).toBe(true);
+    expect((scroller.element as HTMLElement).style.maxHeight).toBe("200px");
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiTabs.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiTabs.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import { defineComponent, ref } from "vue";
+import CuiTabs from "../CuiTabs.vue";
+import CuiTab from "../CuiTab.vue";
+
+function isShown(el: Element): boolean {
+  return (el as HTMLElement).style.display !== "none";
+}
+
+function makeHost(extra: { tabsProps?: string; tabTwoExtra?: string } = {}) {
+  return defineComponent({
+    components: { CuiTabs, CuiTab },
+    setup() {
+      const active = ref("one");
+      return { active };
+    },
+    template: `
+      <CuiTabs v-model="active" ${extra.tabsProps ?? ""}>
+        <CuiTab value="one" label="One">Panel one</CuiTab>
+        <CuiTab value="two" label="Two" ${extra.tabTwoExtra ?? ""}>Panel two</CuiTab>
+      </CuiTabs>
+    `,
+  });
+}
+
+describe("CuiTabs + CuiTab", () => {
+  it("renders a tab button per CuiTab child", async () => {
+    const wrapper = mount(makeHost());
+    await wrapper.vm.$nextTick();
+    const tabs = wrapper.findAll('[role="tab"]');
+    expect(tabs).toHaveLength(2);
+    expect(tabs.map((t) => t.text())).toEqual(["One", "Two"]);
+  });
+
+  it("auto-activates the first tab and shows its panel", async () => {
+    const wrapper = mount(makeHost());
+    await wrapper.vm.$nextTick();
+    const tabs = wrapper.findAll('[role="tab"]');
+    expect(tabs[0].attributes("aria-selected")).toBe("true");
+    expect(tabs[1].attributes("aria-selected")).toBe("false");
+
+    const panels = wrapper.findAll('[role="tabpanel"]');
+    expect(isShown(panels[0].element)).toBe(true);
+    expect(isShown(panels[1].element)).toBe(false);
+  });
+
+  it("clicking a tab switches the active panel", async () => {
+    const wrapper = mount(makeHost());
+    await wrapper.vm.$nextTick();
+    const tabs = wrapper.findAll('[role="tab"]');
+    await tabs[1].trigger("click");
+
+    expect(tabs[1].attributes("aria-selected")).toBe("true");
+    expect(tabs[0].attributes("aria-selected")).toBe("false");
+
+    const panels = wrapper.findAll('[role="tabpanel"]');
+    expect(isShown(panels[0].element)).toBe(false);
+    expect(isShown(panels[1].element)).toBe(true);
+  });
+
+  it("emits update:modelValue and updates the bound v-model when a tab is clicked", async () => {
+    const wrapper = mount(makeHost());
+    await wrapper.vm.$nextTick();
+    await wrapper.findAll('[role="tab"]')[1].trigger("click");
+
+    // bound parent ref reflects the new value
+    expect((wrapper.vm as unknown as { active: string }).active).toBe("two");
+  });
+
+  it("honors v-model: programmatic value change activates the matching panel", async () => {
+    const wrapper = mount(makeHost());
+    await wrapper.vm.$nextTick();
+    expect(isShown(wrapper.findAll('[role="tabpanel"]')[0].element)).toBe(true);
+
+    (wrapper.vm as unknown as { active: string }).active = "two";
+    await wrapper.vm.$nextTick();
+
+    const panels = wrapper.findAll('[role="tabpanel"]');
+    expect(isShown(panels[1].element)).toBe(true);
+    expect(isShown(panels[0].element)).toBe(false);
+    expect(wrapper.findAll('[role="tab"]')[1].attributes("aria-selected")).toBe("true");
+  });
+
+  it("does not activate a disabled tab on click", async () => {
+    const wrapper = mount(makeHost({ tabTwoExtra: "disabled" }));
+    await wrapper.vm.$nextTick();
+    const tabs = wrapper.findAll('[role="tab"]');
+    await tabs[1].trigger("click");
+
+    expect(tabs[0].attributes("aria-selected")).toBe("true");
+    expect(tabs[1].attributes("aria-selected")).toBe("false");
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiTagInput.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiTagInput.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import CuiTagInput from "../CuiTagInput.vue";
+
+describe("CuiTagInput", () => {
+  it("appends a created tag to the v-model array on Enter", async () => {
+    const wrapper = mount(CuiTagInput, {
+      props: { modelValue: ["alpha"] },
+      attachTo: document.body,
+    });
+
+    const input = wrapper.find("input");
+    await input.setValue("beta");
+    await input.trigger("keydown", { key: "Enter" });
+
+    const emitted = wrapper.emitted("update:modelValue");
+    expect(emitted).toBeTruthy();
+    expect(emitted!.at(-1)![0]).toEqual(["alpha", "beta"]);
+
+    wrapper.unmount();
+  });
+
+  it("does not add a duplicate tag", async () => {
+    const wrapper = mount(CuiTagInput, {
+      props: { modelValue: ["alpha"] },
+      attachTo: document.body,
+    });
+
+    const input = wrapper.find("input");
+    await input.setValue("alpha");
+    await input.trigger("keydown", { key: "Enter" });
+
+    // Already present -> addTag bails before emitting.
+    expect(wrapper.emitted("update:modelValue")).toBeFalsy();
+
+    wrapper.unmount();
+  });
+
+  it("removes the last tag on Backspace with an empty query", async () => {
+    const wrapper = mount(CuiTagInput, {
+      props: { modelValue: ["alpha", "beta"] },
+      attachTo: document.body,
+    });
+
+    const input = wrapper.find("input");
+    await input.trigger("keydown", { key: "Backspace" });
+
+    const emitted = wrapper.emitted("update:modelValue");
+    expect(emitted).toBeTruthy();
+    expect(emitted!.at(-1)![0]).toEqual(["alpha"]);
+
+    wrapper.unmount();
+  });
+
+  it("renders the createText label in the create-new dropdown row", async () => {
+    const wrapper = mount(CuiTagInput, {
+      props: { modelValue: [], createText: "Make tag" },
+      attachTo: document.body,
+    });
+
+    const input = wrapper.find("input");
+    await input.trigger("focus");
+    await input.setValue("gamma");
+    await wrapper.vm.$nextTick();
+
+    // Dropdown teleports to body.
+    expect(document.body.textContent).toContain("Make tag");
+    expect(document.body.textContent).toContain("gamma");
+
+    wrapper.unmount();
+  });
+
+  it("does not create when allowCreate is false", async () => {
+    const wrapper = mount(CuiTagInput, {
+      props: { modelValue: [], allowCreate: false },
+      attachTo: document.body,
+    });
+
+    const input = wrapper.find("input");
+    await input.setValue("delta");
+    await input.trigger("keydown", { key: "Enter" });
+
+    expect(wrapper.emitted("update:modelValue")).toBeFalsy();
+
+    wrapper.unmount();
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiTextarea.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiTextarea.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import CuiTextarea from "../CuiTextarea.vue";
+
+describe("CuiTextarea", () => {
+  it("renders modelValue into the native textarea and emits on input (v-model round-trip)", async () => {
+    const wrapper = mount(CuiTextarea, { props: { modelValue: "hello" } });
+    const ta = wrapper.get("textarea");
+    expect((ta.element as HTMLTextAreaElement).value).toBe("hello");
+
+    await ta.setValue("world");
+    expect(wrapper.emitted("update:modelValue")?.at(-1)).toEqual(["world"]);
+  });
+
+  it("respects the rows prop", () => {
+    const wrapper = mount(CuiTextarea, { props: { rows: 7 } });
+    expect(wrapper.get("textarea").attributes("rows")).toBe("7");
+  });
+
+  it("defaults to 3 rows", () => {
+    const wrapper = mount(CuiTextarea);
+    expect(wrapper.get("textarea").attributes("rows")).toBe("3");
+  });
+
+  it("sets the disabled attribute when disabled", () => {
+    const wrapper = mount(CuiTextarea, { props: { disabled: true } });
+    expect(wrapper.get("textarea").attributes("disabled")).toBeDefined();
+    expect(wrapper.find(".cui-textarea--disabled").exists()).toBe(true);
+  });
+
+  it("shows error message and sets aria-invalid when error is set", () => {
+    const wrapper = mount(CuiTextarea, {
+      props: { error: true, errorMessage: "Required field" },
+    });
+    expect(wrapper.get("textarea").attributes("aria-invalid")).toBe("true");
+    const err = wrapper.find(".cui-textarea__error");
+    expect(err.exists()).toBe(true);
+    expect(err.text()).toBe("Required field");
+    expect(wrapper.find(".cui-textarea--error").exists()).toBe(true);
+  });
+
+  it("does not render an error message when error is false", () => {
+    const wrapper = mount(CuiTextarea, { props: { errorMessage: "ignored" } });
+    expect(wrapper.find(".cui-textarea__error").exists()).toBe(false);
+    expect(wrapper.get("textarea").attributes("aria-invalid")).toBeUndefined();
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiTimeline.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiTimeline.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import { defineComponent } from "vue";
+import CuiTimeline from "../CuiTimeline.vue";
+import CuiTimelineItem from "../CuiTimelineItem.vue";
+
+function makeHost(extra: { firstExtra?: string; secondExtra?: string } = {}) {
+  return defineComponent({
+    components: { CuiTimeline, CuiTimelineItem },
+    template: `
+      <CuiTimeline>
+        <CuiTimelineItem title="First" ${extra.firstExtra ?? ""}>Body one</CuiTimelineItem>
+        <CuiTimelineItem title="Second" ${extra.secondExtra ?? ""} last>Body two</CuiTimelineItem>
+      </CuiTimeline>
+    `,
+  });
+}
+
+describe("CuiTimeline + CuiTimelineItem", () => {
+  it("renders the timeline as a list with one listitem per child", () => {
+    const wrapper = mount(makeHost());
+    expect(wrapper.find('[role="list"]').exists()).toBe(true);
+    const items = wrapper.findAll('[role="listitem"]');
+    expect(items).toHaveLength(2);
+    wrapper.unmount();
+  });
+
+  it("renders each item's title and default-slot body content", () => {
+    const wrapper = mount(makeHost());
+    const items = wrapper.findAll('[role="listitem"]');
+    expect(items[0].text()).toContain("First");
+    expect(items[0].text()).toContain("Body one");
+    expect(items[1].text()).toContain("Second");
+    expect(items[1].text()).toContain("Body two");
+    wrapper.unmount();
+  });
+
+  it("renders items in source order", () => {
+    const wrapper = mount(makeHost());
+    const titles = wrapper
+      .findAll('[role="listitem"]')
+      .map((i) => i.text().replace(/Body (one|two)/, "").trim());
+    expect(titles).toEqual(["First", "Second"]);
+    wrapper.unmount();
+  });
+
+  it("applies the per-item color to the dot background", () => {
+    const wrapper = mount(makeHost({ secondExtra: 'color="success"' }));
+    const items = wrapper.findAll('[role="listitem"]');
+    // first item defaults to primary; dot is the first descendant div with a border-radius:50% style
+    const firstDot = items[0].findAll("div").find((d) => d.attributes("style")?.includes("border-radius: 50%"));
+    const secondDot = items[1].findAll("div").find((d) => d.attributes("style")?.includes("border-radius: 50%"));
+    expect(firstDot?.attributes("style")).toContain("var(--cui-primary)");
+    expect(secondDot?.attributes("style")).toContain("var(--cui-success)");
+    wrapper.unmount();
+  });
+
+  it("renders a CuiIcon in place of the plain dot when icon prop is set", () => {
+    const wrapper = mount(makeHost({ firstExtra: 'icon="check"' }));
+    const items = wrapper.findAll('[role="listitem"]');
+    expect(items[0].find(".cui-icon").exists()).toBe(true);
+    // the non-icon item has no icon rendered
+    expect(items[1].find(".cui-icon").exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it("omits the connector line on the item marked last", () => {
+    // first item is not last (has connector), second item has last prop (no connector)
+    const wrapper = mount(makeHost());
+    const items = wrapper.findAll('[role="listitem"]');
+    const connectorsFirst = items[0].findAll("div").filter((d) => d.attributes("style")?.includes("width: 2px"));
+    const connectorsSecond = items[1].findAll("div").filter((d) => d.attributes("style")?.includes("width: 2px"));
+    expect(connectorsFirst.length).toBe(1);
+    expect(connectorsSecond.length).toBe(0);
+    wrapper.unmount();
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiToggleGroup.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiToggleGroup.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import { h } from "vue";
+import CuiToggleGroup from "../CuiToggleGroup.vue";
+import CuiToggle from "../CuiToggle.vue";
+
+describe("CuiToggleGroup", () => {
+  it("adds a toggle's value to the array v-model when clicked", async () => {
+    const wrapper = mount(CuiToggleGroup, {
+      props: { modelValue: [] },
+      slots: {
+        default: () => [
+          h(CuiToggle, { value: "a", label: "A" }),
+          h(CuiToggle, { value: "b", label: "B" }),
+        ],
+      },
+    });
+
+    const toggles = wrapper.findAllComponents(CuiToggle);
+    await toggles[0].trigger("click");
+
+    const emitted = wrapper.emitted("update:modelValue");
+    expect(emitted).toBeTruthy();
+    expect(emitted![0][0]).toEqual(["a"]);
+  });
+
+  it("removes a value from the array v-model when an already-selected toggle is clicked", async () => {
+    const wrapper = mount(CuiToggleGroup, {
+      props: { modelValue: ["a", "b"] },
+      slots: {
+        default: () => [
+          h(CuiToggle, { value: "a", label: "A" }),
+          h(CuiToggle, { value: "b", label: "B" }),
+        ],
+      },
+    });
+
+    const toggles = wrapper.findAllComponents(CuiToggle);
+    await toggles[0].trigger("click");
+
+    expect(wrapper.emitted("update:modelValue")![0][0]).toEqual(["b"]);
+  });
+
+  it("reflects the group's selected values as aria-checked on child toggles", () => {
+    const wrapper = mount(CuiToggleGroup, {
+      props: { modelValue: ["b"] },
+      slots: {
+        default: () => [
+          h(CuiToggle, { value: "a", label: "A" }),
+          h(CuiToggle, { value: "b", label: "B" }),
+        ],
+      },
+    });
+
+    const toggles = wrapper.findAllComponents(CuiToggle);
+    expect(toggles[0].attributes("aria-checked")).toBe("false");
+    expect(toggles[1].attributes("aria-checked")).toBe("true");
+  });
+
+  it("does not emit when the group is disabled", async () => {
+    const wrapper = mount(CuiToggleGroup, {
+      props: { modelValue: [], disabled: true },
+      slots: {
+        default: () => [h(CuiToggle, { value: "a", label: "A" })],
+      },
+    });
+
+    const toggle = wrapper.findComponent(CuiToggle);
+    expect(toggle.attributes("aria-disabled")).toBe("true");
+    await toggle.trigger("click");
+    expect(wrapper.emitted("update:modelValue")).toBeFalsy();
+  });
+
+  it("standalone CuiToggle emits boolean update:modelValue toggling its value", async () => {
+    const wrapper = mount(CuiToggle, {
+      props: { modelValue: false, label: "Solo" },
+    });
+
+    await wrapper.trigger("click");
+    expect(wrapper.emitted("update:modelValue")![0]).toEqual([true]);
+
+    await wrapper.setProps({ modelValue: true });
+    await wrapper.trigger("click");
+    expect(wrapper.emitted("update:modelValue")![1]).toEqual([false]);
+  });
+
+  it("uses vertical orientation automatically for 3+ child toggles", () => {
+    const wrapper = mount(CuiToggleGroup, {
+      props: { modelValue: [] },
+      slots: {
+        default: () => [
+          h(CuiToggle, { value: "a", label: "A" }),
+          h(CuiToggle, { value: "b", label: "B" }),
+          h(CuiToggle, { value: "c", label: "C" }),
+        ],
+      },
+    });
+
+    expect(wrapper.classes()).toContain("cui-toggle-group--vertical");
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/CuiTreeView.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiTreeView.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { mount, type VueWrapper } from "@vue/test-utils";
+import CuiTreeView from "../CuiTreeView.vue";
+import CuiTreeNode from "../CuiTreeNode.vue";
+import type { TreeNode } from "../CuiTreeView.vue";
+
+// Find the CuiTreeNode whose OWN node.id matches, then return its clickable
+// row element (the flex div carrying the @click="onNodeClick" handler — the
+// one immediately containing the node's label/content).
+function rowFor(wrapper: VueWrapper, id: string | number) {
+  const node = wrapper
+    .findAllComponents(CuiTreeNode)
+    .find((c) => (c.props("node") as TreeNode).id === id)!;
+  // Within that node's subtree, the first div bearing display:flex is its own row.
+  return node.findAll("div").find((d) => d.attributes("style")?.includes("display: flex"))!;
+}
+
+const nodes: TreeNode[] = [
+  {
+    id: "fruits",
+    label: "Fruits",
+    children: [
+      { id: "apple", label: "Apple" },
+      { id: "banana", label: "Banana", disabled: true },
+    ],
+  },
+  { id: "veggies", label: "Veggies", children: [{ id: "carrot", label: "Carrot" }] },
+];
+
+// Disable animation so expand/collapse is synchronous (no rAF/setTimeout in jsdom).
+const baseProps = { nodes, animated: false };
+
+describe("CuiTreeView", () => {
+  it("renders a treeitem per top-level node with aria-expanded only on parents", () => {
+    const wrapper = mount(CuiTreeView, { props: baseProps });
+    const items = wrapper.findAll('[role="treeitem"]');
+    // Collapsed: only the 2 top-level nodes are present.
+    expect(items).toHaveLength(2);
+    // Parent nodes (have children) carry aria-expanded; it starts collapsed.
+    expect(items[0].attributes("aria-expanded")).toBe("false");
+  });
+
+  it("expands a node when its chevron is clicked, revealing children", async () => {
+    const wrapper = mount(CuiTreeView, { props: baseProps });
+    expect(wrapper.text()).not.toContain("Apple");
+
+    // Clicking the chevron (the caret icon) toggles expansion.
+    const parent = wrapper.findAll('[role="treeitem"]')[0];
+    await parent.findAllComponents({ name: "CuiIcon" })[0].trigger("click");
+
+    expect(wrapper.text()).toContain("Apple");
+    expect(wrapper.findAll('[role="treeitem"]')[0].attributes("aria-expanded")).toBe("true");
+  });
+
+  it("emits node-expand with the node and expanded state on toggle", async () => {
+    const wrapper = mount(CuiTreeView, { props: baseProps });
+    const parent = wrapper.findAll('[role="treeitem"]')[0];
+    await parent.findAllComponents({ name: "CuiIcon" })[0].trigger("click");
+
+    const expandEvents = wrapper.emitted("node-expand");
+    expect(expandEvents).toHaveLength(1);
+    const [node, isExpanded] = expandEvents![0] as [TreeNode, boolean];
+    expect(node.id).toBe("fruits");
+    expect(isExpanded).toBe(true);
+
+    // Toggle again collapses.
+    await wrapper.findAll('[role="treeitem"]')[0].findAllComponents({ name: "CuiIcon" })[0].trigger("click");
+    const second = wrapper.emitted("node-expand")![1] as [TreeNode, boolean];
+    expect(second[1]).toBe(false);
+  });
+
+  it("emits node-click and update:modelValue when a selectable leaf is clicked", async () => {
+    const wrapper = mount(CuiTreeView, {
+      props: { ...baseProps, defaultExpanded: ["fruits"] },
+    });
+    await rowFor(wrapper, "apple").trigger("click");
+
+    expect(wrapper.emitted("node-click")).toHaveLength(1);
+    expect((wrapper.emitted("node-click")![0][0] as TreeNode).id).toBe("apple");
+    expect(wrapper.emitted("update:modelValue")![0]).toEqual(["apple"]);
+  });
+
+  it("toggles selection off in single mode when the selected node is clicked again", async () => {
+    const wrapper = mount(CuiTreeView, {
+      props: { ...baseProps, defaultExpanded: ["fruits"], modelValue: "apple" },
+    });
+    await rowFor(wrapper, "apple").trigger("click");
+
+    // Already selected → clicking again clears selection to null.
+    expect(wrapper.emitted("update:modelValue")![0]).toEqual([null]);
+  });
+
+  it("accumulates selection ids in multiple mode", async () => {
+    const wrapper = mount(CuiTreeView, {
+      props: { ...baseProps, multiple: true, defaultExpanded: ["fruits"], modelValue: ["apple"] },
+    });
+    // Selecting Fruits (a parent, but selectable=true so it selects) adds to the array.
+    await rowFor(wrapper, "fruits").trigger("click");
+
+    expect(wrapper.emitted("update:modelValue")![0]).toEqual([["apple", "fruits"]]);
+  });
+
+  it("does not select disabled nodes", async () => {
+    const wrapper = mount(CuiTreeView, {
+      props: { ...baseProps, defaultExpanded: ["fruits"] },
+    });
+    await rowFor(wrapper, "banana").trigger("click");
+
+    expect(wrapper.emitted("node-click")).toBeUndefined();
+    expect(wrapper.emitted("update:modelValue")).toBeUndefined();
+  });
+});

--- a/packages/clean-ui/src/components/__tests__/smoke.test.ts
+++ b/packages/clean-ui/src/components/__tests__/smoke.test.ts
@@ -81,9 +81,12 @@ describe("smoke: every public component mounts and renders a root", () => {
   }
 });
 
+// Providers render only their slot (no root element), so `hidden` has nowhere to apply.
+const FRAGMENT_ROOT = new Set(["CuiConfigProvider", "CuiToastProvider"]);
+
 describe("smoke: components respect `hidden`", () => {
   for (const [name, comp] of components) {
-    if (SKIP[name]) continue;
+    if (SKIP[name] || FRAGMENT_ROOT.has(name)) continue;
     it(`${name} mounts with hidden=true`, () => {
       const wrapper = mount(comp, { props: { ...(PROPS[name] ?? {}), hidden: true } });
       expect(wrapper.exists()).toBe(true);

--- a/packages/clean-ui/src/components/__tests__/smoke.test.ts
+++ b/packages/clean-ui/src/components/__tests__/smoke.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import type { Component } from "vue";
+import * as CleanUI from "../../index";
+
+/**
+ * Breadth smoke test: every public component must mount without throwing and
+ * render a real root node. Depth (v-model, events, focus, keyboard) lives in the
+ * per-component behaviour test files.
+ *
+ * Sub-components that require a parent provider's injected context can't mount
+ * standalone — they're SKIPPED here with a reason and covered by their parent's
+ * behaviour tests.
+ */
+
+const SKIP: Record<string, string> = {
+  CuiTab: "requires <CuiTabs> context",
+  CuiAccordionItem: "requires <CuiAccordion> context",
+  CuiBreadcrumbItem: "requires <CuiBreadcrumb> context",
+  // Table sub-components require <CuiTable> table-context
+  CuiTableHead: "requires <CuiTable> context",
+  CuiTableBody: "requires <CuiTable> context",
+  CuiTableFoot: "requires <CuiTable> context",
+  CuiTableRow: "requires <CuiTable> context",
+  CuiTableCell: "requires <CuiTable> context",
+  // Dropdown sub-components require <CuiDropdown> context
+  CuiDropdownTrigger: "requires <CuiDropdown> context",
+  CuiDropdownMenu: "requires <CuiDropdown> context",
+  CuiDropdownItem: "requires <CuiDropdown> context",
+  CuiDropdownCheckItem: "requires <CuiDropdown> context",
+  CuiDropdownRadioGroup: "requires <CuiDropdown> context",
+  CuiDropdownRadioItem: "requires <CuiDropdown> context",
+  CuiDropdownSub: "requires <CuiDropdown> context",
+  CuiDropdownDivider: "requires <CuiDropdown> context",
+  CuiDropdownHeader: "requires <CuiDropdown> context",
+  CuiTimelineItem: "requires <CuiTimeline> context",
+};
+
+/** Minimal props for components that need them to render meaningfully. */
+const PROPS: Record<string, Record<string, unknown>> = {
+  CuiFieldset: { legend: "Legend" },
+  CuiModal: { visible: true, title: "Title" },
+  CuiSlideover: { visible: true },
+  CuiConfirmDialog: { visible: true },
+  CuiPopover: { visible: true },
+  // Required props
+  CuiIcon: { name: "info" },
+  CuiMaskedInput: { mask: "###-###" },
+  CuiCodeBlock: { code: "const x = 1;" },
+  CuiDataGrid: { columns: [], data: [] },
+  CuiTransferList: { items: [] },
+};
+
+function isComponent(value: unknown): value is Component {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    ("__name" in value || "render" in value || "setup" in value)
+  );
+}
+
+const components = Object.entries(CleanUI).filter(([, v]) => isComponent(v)) as [string, Component][];
+
+describe("smoke: public component inventory", () => {
+  it("discovers a substantial number of components", () => {
+    expect(components.length).toBeGreaterThan(80);
+  });
+});
+
+describe("smoke: every public component mounts and renders a root", () => {
+  for (const [name, comp] of components) {
+    if (SKIP[name]) {
+      it.skip(`${name} — skipped (${SKIP[name]})`, () => {});
+      continue;
+    }
+    it(`${name} mounts without error`, () => {
+      const wrapper = mount(comp, { props: PROPS[name] ?? {} });
+      expect(wrapper.exists()).toBe(true);
+      wrapper.unmount();
+    });
+  }
+});
+
+describe("smoke: components respect `hidden`", () => {
+  for (const [name, comp] of components) {
+    if (SKIP[name]) continue;
+    it(`${name} mounts with hidden=true`, () => {
+      const wrapper = mount(comp, { props: { ...(PROPS[name] ?? {}), hidden: true } });
+      expect(wrapper.exists()).toBe(true);
+      wrapper.unmount();
+    });
+  }
+});

--- a/packages/clean-ui/src/components/__tests__/smoke.test.ts
+++ b/packages/clean-ui/src/components/__tests__/smoke.test.ts
@@ -13,27 +13,28 @@ import * as CleanUI from "../../index";
  * behaviour tests.
  */
 
+// Sub-components that can't mount standalone (need a parent's injected context).
+// Each is exercised in its parent's behaviour test — referenced here so a "skip"
+// reads as "covered elsewhere", not "untested".
 const SKIP: Record<string, string> = {
-  CuiTab: "requires <CuiTabs> context",
-  CuiAccordionItem: "requires <CuiAccordion> context",
-  CuiBreadcrumbItem: "requires <CuiBreadcrumb> context",
-  // Table sub-components require <CuiTable> table-context
-  CuiTableHead: "requires <CuiTable> context",
-  CuiTableBody: "requires <CuiTable> context",
-  CuiTableFoot: "requires <CuiTable> context",
-  CuiTableRow: "requires <CuiTable> context",
-  CuiTableCell: "requires <CuiTable> context",
-  // Dropdown sub-components require <CuiDropdown> context
-  CuiDropdownTrigger: "requires <CuiDropdown> context",
-  CuiDropdownMenu: "requires <CuiDropdown> context",
-  CuiDropdownItem: "requires <CuiDropdown> context",
-  CuiDropdownCheckItem: "requires <CuiDropdown> context",
-  CuiDropdownRadioGroup: "requires <CuiDropdown> context",
-  CuiDropdownRadioItem: "requires <CuiDropdown> context",
-  CuiDropdownSub: "requires <CuiDropdown> context",
-  CuiDropdownDivider: "requires <CuiDropdown> context",
-  CuiDropdownHeader: "requires <CuiDropdown> context",
-  CuiTimelineItem: "requires <CuiTimeline> context",
+  CuiTab: "needs <CuiTabs> context — covered by CuiTabs.test.ts",
+  CuiAccordionItem: "needs <CuiAccordion> context — covered by CuiAccordion.test.ts",
+  CuiBreadcrumbItem: "needs <CuiBreadcrumb> context — covered by CuiBreadcrumb.test.ts",
+  CuiTableHead: "needs <CuiTable> context — covered by CuiTable.test.ts",
+  CuiTableBody: "needs <CuiTable> context — covered by CuiTable.test.ts",
+  CuiTableFoot: "needs <CuiTable> context — covered by CuiTable.test.ts",
+  CuiTableRow: "needs <CuiTable> context — covered by CuiTable.test.ts",
+  CuiTableCell: "needs <CuiTable> context — covered by CuiTable.test.ts",
+  CuiDropdownTrigger: "needs <CuiDropdown> context — covered by CuiDropdown.test.ts",
+  CuiDropdownMenu: "needs <CuiDropdown> context — covered by CuiDropdown.test.ts",
+  CuiDropdownItem: "needs <CuiDropdown> context — covered by CuiDropdown.test.ts",
+  CuiDropdownCheckItem: "needs <CuiDropdown> context — covered by CuiDropdown.test.ts",
+  CuiDropdownRadioGroup: "needs <CuiDropdown> context — covered by CuiDropdown.test.ts",
+  CuiDropdownRadioItem: "needs <CuiDropdown> context — covered by CuiDropdown.test.ts",
+  CuiDropdownSub: "needs <CuiDropdown> context — covered by CuiDropdown.test.ts",
+  CuiDropdownDivider: "needs <CuiDropdown> context — covered by CuiDropdown.test.ts",
+  CuiDropdownHeader: "needs <CuiDropdown> context — covered by CuiDropdown.test.ts",
+  CuiTimelineItem: "needs <CuiTimeline> context — covered by CuiTimeline.test.ts",
 };
 
 /** Minimal props for components that need them to render meaningfully. */

--- a/packages/clean-ui/src/components/__tests__/smoke.test.ts
+++ b/packages/clean-ui/src/components/__tests__/smoke.test.ts
@@ -49,6 +49,10 @@ const PROPS: Record<string, Record<string, unknown>> = {
   CuiCodeBlock: { code: "const x = 1;" },
   CuiDataGrid: { columns: [], data: [] },
   CuiTransferList: { items: [] },
+  CuiRadio: { value: "smoke" },
+  CuiCopyButton: { value: "copy me" },
+  CuiStepper: { steps: [] },
+  CuiTreeView: { nodes: [] },
 };
 
 function isComponent(value: unknown): value is Component {

--- a/packages/clean-ui/src/test-setup.ts
+++ b/packages/clean-ui/src/test-setup.ts
@@ -1,0 +1,39 @@
+import { vi } from "vitest";
+
+// jsdom doesn't implement these browser APIs that layout/observer components use.
+// Stub them so components mount cleanly under test.
+
+if (!window.matchMedia) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+if (!("ResizeObserver" in globalThis)) {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+
+if (!("IntersectionObserver" in globalThis)) {
+  globalThis.IntersectionObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return [];
+    }
+    root = null;
+    rootMargin = "";
+    thresholds = [];
+  } as unknown as typeof IntersectionObserver;
+}

--- a/packages/clean-ui/vitest.config.ts
+++ b/packages/clean-ui/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
   plugins: [vue()],
   test: {
     environment: "jsdom",
+    setupFiles: ["./src/test-setup.ts"],
   },
 });


### PR DESCRIPTION
Closes #3.

Takes the library from **1 (broken) test file** to a real suite: breadth coverage across all components, behavior tests for the interactive set, and a CI merge gate.

## Acceptance criteria
- [x] **Smoke coverage across all components** — one data-driven `smoke.test.ts`: every public component mounts without error, renders a root, and tolerates `hidden`. 153 assertions; 18 context-only sub-components skipped with documented reasons.
- [x] **Behavior tests for the interactive set** — 24 components with focused `@vue/test-utils` tests (~143 assertions).
- [x] **CI gate on typecheck + tests** — `.github/workflows/ci.yml` runs library build (`vue-tsc`) + `vitest` + docs type-check on PRs/pushes to develop/master. (This PR is the gate's first run.)

## What's here
- **Fixed the 3 stale `CuiButton` tests** — they asserted Tailwind classes the button dropped when it moved to `cui-button` + inline styles. Now assert real behavior (default variant `outline`, size→inline height, `<a>` for href, disabled, aria-busy, click).
- **`smoke.test.ts`** — discovers components from the public exports, mounts each with minimal/required props; per-component skip + props config for the context-dependent and required-prop cases.
- **`test-setup.ts`** — jsdom polyfills (`matchMedia`/`ResizeObserver`/`IntersectionObserver`) wired via vitest `setupFiles`, so layout/observer components mount under test.
- **Behavior tests** (24 files): Input, Textarea, MaskedInput, Checkbox/Radio/Toggle groups (+ children), Select, Combobox, Slider, InputStepper, TagInput, Rating, Modal, Slideover, ConfirmDialog, Popover, Dropdown, Tabs, Accordion, Pagination, Form, TreeView, CopyButton, Badge.

## Results
```
Test Files  28 passed (28)
     Tests  316 passed | 18 skipped (334)
```
Library build (`vue-tsc`) green; docs type-check green.

## How it was built
Foundation (CuiButton fix, smoke harness, polyfills, CI gate) by hand. The 24 behavior-test files were authored by a fan-out of one agent per component, each reading the component's real API and self-verifying with vitest; I then ran the **full suite together** as the safety net (catches teleport/timer/global-state interactions the per-file runs miss), removed one agent's debug scratch file, and spot-checked several files for substance.

## Notes for the reviewer
- Skipped in smoke (need parent context, covered via their parent's behavior test): `CuiTab`, `CuiAccordionItem`, `CuiBreadcrumbItem`, the `CuiTable*` and `CuiDropdown*` sub-components, `CuiTimelineItem`.
- Long-tail follow-ups (not blocking): focus-trap assertions for overlays, deeper keyboard-nav matrices, `clampSize` edge-case unit tests, and display-only components beyond smoke.