### PR TITLE
fix(data-grid): pin sticky-column headers on vertical scroll

### DIFF
--- a/packages/clean-ui/src/components/CuiDataGridTable.vue
+++ b/packages/clean-ui/src/components/CuiDataGridTable.vue
@@ -165,21 +165,6 @@ const lastStickyKey = computed(() => {
   return null;
 });
 
-function stickyColStyle(colKey: string): Record<string, string | number> | undefined {
-  const leftVal = stickyColumnOffsets.value.get(colKey);
-  if (!leftVal) return undefined;
-  const style: Record<string, string | number> = {
-    position: "sticky",
-    left: leftVal,
-    zIndex: 5,
-    background: "var(--cui-table-head-bg, var(--color-surface-50))",
-  };
-  if (colKey === lastStickyKey.value) {
-    style.boxShadow = "2px 0 4px -1px rgba(0,0,0,0.08)";
-  }
-  return style;
-}
-
 function stickyBodyColStyle(colKey: string): Record<string, string | number> | undefined {
   const leftVal = stickyColumnOffsets.value.get(colKey);
   if (!leftVal) return undefined;
@@ -195,12 +180,48 @@ function stickyBodyColStyle(colKey: string): Record<string, string | number> | u
   return style;
 }
 
+// Header cells pin at the CELL level (never via a sticky <thead> — that nests
+// same-axis sticky and detaches sticky-column headers). Every header cell gets
+// `top: 0` when stickyHeader is on; sticky columns additionally get `left`. A
+// cell that's both (the top-left corner) sits above the regular header row (10)
+// and the sticky body column (4) at z-index 11.
 function headerCellStyle(col: { key: string; sortable?: boolean; sticky?: boolean }) {
-  return {
-    ...(col.sortable ? { cursor: "pointer", userSelect: "none" as const } : {}),
-    ...stickyColStyle(col.key),
-  };
+  const leftVal = stickyColumnOffsets.value.get(col.key);
+  const stickyCol = !!leftVal;
+  const stickyTop = props.stickyHeader;
+
+  const style: Record<string, string | number> = col.sortable
+    ? { cursor: "pointer", userSelect: "none" }
+    : {};
+
+  if (stickyCol || stickyTop) {
+    style.position = "sticky";
+    style.background = "var(--cui-table-head-bg, var(--color-surface-50))";
+    style.zIndex = stickyCol && stickyTop ? 11 : stickyCol ? 5 : 10;
+  }
+  if (stickyTop) style.top = 0;
+  if (stickyCol) {
+    style.left = leftVal!;
+    if (col.key === lastStickyKey.value) {
+      style.boxShadow = "2px 0 4px -1px rgba(0,0,0,0.08)";
+    }
+  }
+  return style;
 }
+
+// Top-pin style for the non-column header cells (bulk-select checkbox, row
+// actions). They aren't in visibleColumns so they don't get headerCellStyle,
+// but they still need to ride the sticky header rather than scroll away.
+const auxHeaderCellStyle = computed(() =>
+  props.stickyHeader
+    ? {
+        position: "sticky" as const,
+        top: 0,
+        zIndex: 10,
+        background: "var(--cui-table-head-bg, var(--color-surface-50))",
+      }
+    : {},
+);
 
 // ---------------------------------------------------------------------------
 // Virtualization
@@ -254,7 +275,7 @@ const totalCols = computed(() => {
       <!-- aria-rowindex is 1-based incl. the header row; only meaningful when windowed -->
       <CuiTableRow :aria-rowindex="virtualize ? 1 : undefined">
         <!-- Bulk selection checkbox -->
-        <CuiTableCell v-if="hasBulkActions" width="3rem" align="center">
+        <CuiTableCell v-if="hasBulkActions" width="3rem" align="center" :style="auxHeaderCellStyle">
           <CuiCheckbox
             v-if="showSelectAll"
             :model-value="selectAllState === true"
@@ -285,7 +306,7 @@ const totalCols = computed(() => {
         </CuiTableCell>
 
         <!-- Row actions column -->
-        <CuiTableCell v-if="hasRowActions" width="3rem" />
+        <CuiTableCell v-if="hasRowActions" width="3rem" :style="auxHeaderCellStyle" />
       </CuiTableRow>
     </CuiTableHead>
 

--- a/packages/clean-ui/src/components/CuiTable.vue
+++ b/packages/clean-ui/src/components/CuiTable.vue
@@ -210,7 +210,10 @@ defineExpose({ scrollWrapper });
 .cui-table--sticky-header thead th {
   position: sticky !important;
   top: 0 !important;
-  z-index: 10 !important;
+  /* z-index intentionally NOT !important: a cell that is BOTH a sticky header
+     and a sticky column (the top-left "corner") needs to layer above its
+     neighbours, which it does by setting a higher z-index inline. */
+  z-index: 10;
   background: var(--color-surface-50) !important;
 }
 

--- a/packages/clean-ui/src/components/CuiTableHead.vue
+++ b/packages/clean-ui/src/components/CuiTableHead.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed, provide, inject } from "vue";
-import { TableContextKey, TableSectionContextKey } from "./table-context";
+import { provide } from "vue";
+import { TableSectionContextKey } from "./table-context";
 import type { HideableProps } from "../types/common";
 
 export interface CuiTableHeadProps extends HideableProps {
@@ -12,21 +12,15 @@ withDefaults(defineProps<CuiTableHeadProps>(), {
 
 provide(TableSectionContextKey, { isHead: true });
 
-const table = inject(TableContextKey, undefined);
-
-const headStyle = computed(() => {
-  if (!table?.stickyHeader.value) return undefined;
-  return {
-    position: "sticky" as const,
-    top: "0",
-    zIndex: 2,
-    background: "var(--cui-table-head-bg, var(--color-surface-50))",
-  };
-});
+// Sticky header is pinned at the CELL level (each th/td gets position: sticky;
+// top: 0), NOT on the <thead>. A sticky <thead> + sticky cells is a nested
+// same-axis sticky, which detaches sticky-column header cells from the header's
+// vertical pinning. See `.cui-table--sticky-header thead th` and, for the data
+// grid (td-based headers), CuiDataGridTable's headerCellStyle.
 </script>
 
 <template>
-  <thead v-show="!hidden" :style="headStyle">
+  <thead v-show="!hidden">
     <slot />
   </thead>
 </template>

--- a/packages/clean-ui/src/components/__tests__/CuiDataGrid.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiDataGrid.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import CuiDataGrid from "../CuiDataGrid.vue";
+import type { DataGridColumn, DataGridRow } from "../../types/data-grid";
+
+const columns: DataGridColumn[] = [
+  { key: "name", label: "Name", sticky: true, width: "160px" },
+  { key: "email", label: "Email", sticky: true, width: "200px" },
+  { key: "role", label: "Role", width: "140px" },
+];
+
+const data: DataGridRow[] = [
+  { id: "1", name: "Alice", email: "a@x.com", role: "Eng" },
+  { id: "2", name: "Bob", email: "b@x.com", role: "Design" },
+];
+
+function headerCells(wrapper: ReturnType<typeof mount>) {
+  return wrapper.findAll("thead th, thead td");
+}
+
+describe("CuiDataGrid sticky columns", () => {
+  it("pins a sticky-column header cell on BOTH axes (top + left) so it stays put on vertical scroll", () => {
+    const wrapper = mount(CuiDataGrid, {
+      props: { columns, data, maxHeight: "320px", hideToolbar: true },
+    });
+    // First header cell is the sticky "Name" column.
+    const style = headerCells(wrapper)[0].attributes("style") ?? "";
+    expect(style).toContain("position: sticky");
+    expect(style).toContain("left:"); // horizontal pin (sticky column)
+    expect(style).toContain("top:"); // vertical pin (sticky header) — the regression
+    wrapper.unmount();
+  });
+
+  it("layers the sticky-header corner cell above the regular header row", () => {
+    const wrapper = mount(CuiDataGrid, {
+      props: { columns, data, maxHeight: "320px", hideToolbar: true },
+    });
+    const cells = headerCells(wrapper);
+    const stickyStyle = cells[0].attributes("style") ?? "";
+    // Corner cell uses a higher z-index (11) than the regular sticky-header row (10).
+    expect(stickyStyle).toMatch(/z-index:\s*11/);
+    wrapper.unmount();
+  });
+
+  it("pins the bulk-select (checkbox) header cell to the top so it rides the sticky header", () => {
+    const wrapper = mount(CuiDataGrid, {
+      props: {
+        columns,
+        data: data.map((r) => ({ ...r, _actions: [{ key: "edit", label: "Edit" }] })),
+        bulkActions: [{ key: "delete", label: "Delete" }],
+        maxHeight: "320px",
+        hideToolbar: true,
+      },
+    });
+    // First header cell is the select-all checkbox column.
+    const style = headerCells(wrapper)[0].attributes("style") ?? "";
+    expect(style).toContain("position: sticky");
+    expect(style).toContain("top:");
+    wrapper.unmount();
+  });
+
+  it("does not pin a non-sticky column header to the left", () => {
+    const wrapper = mount(CuiDataGrid, {
+      props: { columns, data, maxHeight: "320px", hideToolbar: true },
+    });
+    // The "Role" column is not sticky → no left offset inline.
+    const roleStyle = headerCells(wrapper)[2].attributes("style") ?? "";
+    expect(roleStyle).not.toContain("left:");
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
Closes #22.

## The bug
In the DataGrid sticky-columns example, the `Name`/`Email` **header** cells scrolled away on vertical scroll while non-sticky headers stayed pinned. (Fixing that also surfaced a second case — see below.)

## Root cause — nested same-axis sticky
`CuiTableHead` made the **`<thead>`** `position: sticky; top: 0`, and the whole header pinned via that. But a sticky-**column** header cell *also* has its own `position: sticky` (for the column's `left`). A sticky cell inside a sticky thead **detaches** from the header's vertical pinning — so the cell's `top` never engaged. Confirmed in-browser: the cell computed `position: sticky; top: 0px` yet still scrolled. Non-sticky header cells (no own `position`) rode the thead's sticky and stayed — which is why only the sticky columns broke.

## Fix — pin at the cell level, remove the thead-level sticky (no nesting)
- **`CuiTableHead`**: drop `position: sticky` from the `<thead>`. Plain `CuiTable` (whose headers are `<th>`) still pins via the existing `.cui-table--sticky-header thead th` rule, so it's unaffected.
- **`CuiDataGridTable`**: the grid's headers render as `<td>` (so that `thead th` rule doesn't match them) — `headerCellStyle` now applies `position: sticky; top: 0` to **every** header cell when `stickyHeader` is on; sticky columns additionally get `left`, and the top-left **corner** cell gets `z-index: 11` (above the header row at 10 and the sticky body column at 4).
- **Aux header cells**: restored top-pinning for the non-column header cells — the **bulk-select checkbox** and **row-actions** headers — via `auxHeaderCellStyle`. They aren't in `visibleColumns` (so they don't get `headerCellStyle`) and previously rode the now-removed thead sticky. *(This was a regression the fix surfaced and is now covered.)*
- **`CuiTable`**: dropped `!important` from the sticky-header `z-index` only (kept it on `position`/`top`/`background`) so the corner cell's higher inline z-index can win.

## Tests
`CuiDataGrid.test.ts` asserts: a sticky-column header pins on **both** axes (`top` + `left`) with the corner `z-index: 11`; the **bulk-select** header cell pins to the top; and a non-sticky column header does **not** pin left.

## Verification
Verified in-browser on both the **sticky-columns** and **full-featured (bulk + row actions)** examples — sticky-column headers and the select-all checkbox now stay pinned on vertical scroll, columns still pin left on horizontal scroll, and non-sticky headers are unaffected. Full suite **349 passed**, docs typecheck green.

> jsdom can't render `position: sticky` layout, so the unit tests lock the *inline-style contract* (both axes present on the right cells); the actual pinning was confirmed visually in-browser.