### PR TITLE
feat(docs): scrollbar utility, changelog page + version badge, density callout

### DIFF
--- a/apps/docs/src/App.vue
+++ b/apps/docs/src/App.vue
@@ -10,6 +10,7 @@ import {
   CuiDropdownRadioItem,
   CuiDropdownHeader,
   CuiIcon,
+  CuiBadge,
   CuiSlideover,
   CuiToastProvider,
   useTheme,
@@ -17,6 +18,9 @@ import {
 } from "@itguy614/clean-ui";
 import Navigation from "./components/Navigation.vue";
 import { ShowDebugKey } from "./keys";
+import versionRaw from "../../../VERSION?raw";
+
+const version = versionRaw.trim();
 
 const isDark = ref(false);
 const showDebug = ref(false);
@@ -84,8 +88,14 @@ function toggleDark() {
               </CuiButton>
             </div>
 
-            <!-- Spacer on desktop where hamburger would be -->
-            <div class="hidden lg:block" />
+            <!-- Brand + version (links to changelog) -->
+            <RouterLink
+              to="/changelog"
+              :style="{ display: 'inline-flex', alignItems: 'center', gap: '0.5rem', textDecoration: 'none', color: 'var(--cui-text-body)' }"
+            >
+              <span :style="{ fontWeight: '600', fontSize: '0.9375rem' }">clean-ui</span>
+              <CuiBadge color="primary" size="sm">v{{ version }}</CuiBadge>
+            </RouterLink>
 
             <!-- Right: theme / debug / dark toggle -->
             <div :style="{ display: 'flex', alignItems: 'center', gap: '0.5rem' }">

--- a/apps/docs/src/App.vue
+++ b/apps/docs/src/App.vue
@@ -10,7 +10,6 @@ import {
   CuiDropdownRadioItem,
   CuiDropdownHeader,
   CuiIcon,
-  CuiBadge,
   CuiSlideover,
   CuiToastProvider,
   useTheme,
@@ -18,9 +17,6 @@ import {
 } from "@itguy614/clean-ui";
 import Navigation from "./components/Navigation.vue";
 import { ShowDebugKey } from "./keys";
-import versionRaw from "../../../VERSION?raw";
-
-const version = versionRaw.trim();
 
 const isDark = ref(false);
 const showDebug = ref(false);
@@ -88,14 +84,8 @@ function toggleDark() {
               </CuiButton>
             </div>
 
-            <!-- Brand + version (links to changelog) -->
-            <RouterLink
-              to="/changelog"
-              :style="{ display: 'inline-flex', alignItems: 'center', gap: '0.5rem', textDecoration: 'none', color: 'var(--cui-text-body)' }"
-            >
-              <span :style="{ fontWeight: '600', fontSize: '0.9375rem' }">clean-ui</span>
-              <CuiBadge color="primary" size="sm">v{{ version }}</CuiBadge>
-            </RouterLink>
+            <!-- Spacer on desktop where hamburger would be -->
+            <div class="hidden lg:block" />
 
             <!-- Right: theme / debug / dark toggle -->
             <div :style="{ display: 'flex', alignItems: 'center', gap: '0.5rem' }">

--- a/apps/docs/src/components/Navigation.vue
+++ b/apps/docs/src/components/Navigation.vue
@@ -132,7 +132,7 @@ const groupedSections = sections.reduce((acc, section) => {
                 'block w-full rounded-md px-3 py-2 text-left text-sm transition-colors',
                 'text-surface-700 hover:bg-surface-200 dark:text-surface-300 dark:hover:bg-surface-800'
               ]"
-              active-class="text-white [background:var(--cui-primary)] hover:[background:var(--cui-primary-hover)]"
+              active-class="[color:var(--cui-primary-text)] [background:var(--cui-primary-solid,var(--cui-primary))] hover:[background:var(--cui-primary-solid-hover,var(--cui-primary-hover))]"
               @click="$emit('navigate')"
             >
               {{ section.label }}

--- a/apps/docs/src/components/Navigation.vue
+++ b/apps/docs/src/components/Navigation.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
+import { CuiBadge } from "@itguy614/clean-ui";
+import versionRaw from "../../../../VERSION?raw";
+
 defineEmits<{ navigate: [] }>();
+
+const version = versionRaw.trim();
 
 const sections = [
   // Getting Started
@@ -102,9 +107,15 @@ const groupedSections = sections.reduce((acc, section) => {
 </script>
 
 <template>
-  <nav :style="{ height: '100%', overflowY: 'auto', padding: '1.5rem', background: 'var(--color-surface-50)' }">
+  <nav
+    class="cui-scrollbar bg-surface-50 dark:bg-surface-900 border-r border-surface-200 dark:border-surface-800"
+    :style="{ height: '100%', overflowY: 'auto', padding: '1.5rem' }"
+  >
     <div style="margin-bottom: 1.5rem;">
-      <h2 style="font-size: 1.25rem; font-weight: 700;">Clean UI</h2>
+      <div style="display: flex; align-items: center; gap: 0.5rem;">
+        <h2 style="font-size: 1.25rem; font-weight: 700; color: var(--cui-text-emphasis);">Clean UI</h2>
+        <CuiBadge color="primary" size="sm">v{{ version }}</CuiBadge>
+      </div>
       <p style="margin-top: 0.25rem; font-size: 0.875rem; color: var(--cui-text-secondary);">Vue Component Library</p>
     </div>
 

--- a/apps/docs/src/components/Navigation.vue
+++ b/apps/docs/src/components/Navigation.vue
@@ -5,6 +5,7 @@ const sections = [
   // Getting Started
   { id: "overview", label: "Overview", path: "/", group: "Getting Started" },
   { id: "installation", label: "Installation", path: "/installation", group: "Getting Started" },
+  { id: "changelog", label: "Changelog", path: "/changelog", group: "Getting Started" },
 
   // Foundations (alphabetical)
   { id: "colors", label: "Colors", path: "/foundations/colors", group: "Foundations" },

--- a/apps/docs/src/components/Navigation.vue
+++ b/apps/docs/src/components/Navigation.vue
@@ -14,6 +14,7 @@ const sections = [
   { id: "typography", label: "Typography", path: "/foundations/typography", group: "Foundations" },
   { id: "localization", label: "Localization", path: "/foundations/localization", group: "Foundations" },
   { id: "density", label: "Density", path: "/foundations/density", group: "Foundations" },
+  { id: "utilities", label: "Utilities", path: "/foundations/utilities", group: "Foundations" },
 
   // Layout (alphabetical)
   { id: "container", label: "Container", path: "/components/container", group: "Layout" },

--- a/apps/docs/src/pages/ChangelogPage.vue
+++ b/apps/docs/src/pages/ChangelogPage.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { CuiStack, CuiCard, CuiCardBody, CuiBadge, type CuiColor } from "@itguy614/clean-ui";
+import changelogRaw from "../../../../CHANGELOG.md?raw";
+
+interface Section {
+  title: string;
+  items: string[];
+}
+interface Release {
+  version: string;
+  date: string;
+  sections: Section[];
+}
+
+// Parse the Keep a Changelog structure:
+//   ## [x.y.z] - YYYY-MM-DD   → release
+//   ### Section               → section
+//   - item                    → list item
+const releases = computed<Release[]>(() => {
+  const out: Release[] = [];
+  let release: Release | null = null;
+  let section: Section | null = null;
+
+  for (const raw of changelogRaw.split("\n")) {
+    const line = raw.trimEnd();
+
+    const rel = line.match(/^##\s+\[([^\]]+)\]\s*-\s*(.+)$/);
+    if (rel) {
+      release = { version: rel[1], date: rel[2].trim(), sections: [] };
+      out.push(release);
+      section = null;
+      continue;
+    }
+
+    const sec = line.match(/^###\s+(.+)$/);
+    if (sec && release) {
+      section = { title: sec[1].trim(), items: [] };
+      release.sections.push(section);
+      continue;
+    }
+
+    const item = line.match(/^[-*]\s+(.+)$/);
+    if (item && section) {
+      section.items.push(item[1].trim());
+    }
+  }
+  return out;
+});
+
+// Section label → semantic color (Keep a Changelog vocabulary).
+const SECTION_COLORS: Record<string, CuiColor> = {
+  Added: "success",
+  Changed: "info",
+  Fixed: "warning",
+  Removed: "error",
+  Deprecated: "secondary",
+  Security: "error",
+  Documentation: "secondary",
+};
+function sectionColor(title: string): CuiColor {
+  return SECTION_COLORS[title] ?? "secondary";
+}
+
+// Minimal inline markdown for changelog items (trusted, build-time content):
+// escape HTML, then render **bold** and `code`.
+function inlineMd(text: string): string {
+  const escaped = text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+  return escaped
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(/`([^`]+)`/g, '<code class="cui-code">$1</code>');
+}
+</script>
+
+<template>
+  <CuiStack spacing="8" class="cui-typography">
+    <div>
+      <h1>Changelog</h1>
+      <p class="cui-lead">
+        Notable changes to <code class="cui-code">@itguy614/clean-ui</code>, following
+        <a href="https://keepachangelog.com/en/1.0.0/" target="_blank" rel="noopener" style="color: var(--cui-primary);">Keep a Changelog</a>.
+        Sourced from <code class="cui-code">CHANGELOG.md</code>.
+      </p>
+    </div>
+
+    <CuiStack spacing="6">
+      <CuiCard v-for="release in releases" :key="release.version" variant="outline">
+        <CuiCardBody>
+          <div style="display: flex; align-items: baseline; gap: 0.625rem; flex-wrap: wrap;">
+            <h2 style="margin: 0; font-size: 1.375rem;">{{ release.version }}</h2>
+            <span style="font-size: 0.8125rem; color: var(--cui-text-tertiary);">{{ release.date }}</span>
+          </div>
+
+          <div v-for="section in release.sections" :key="section.title" style="margin-top: 1rem;">
+            <CuiBadge :color="sectionColor(section.title)" size="sm">{{ section.title }}</CuiBadge>
+            <ul style="margin-top: 0.5rem;">
+              <li v-for="(item, i) in section.items" :key="i" v-html="inlineMd(item)" />
+            </ul>
+          </div>
+        </CuiCardBody>
+      </CuiCard>
+    </CuiStack>
+  </CuiStack>
+</template>

--- a/apps/docs/src/pages/Overview.vue
+++ b/apps/docs/src/pages/Overview.vue
@@ -234,26 +234,5 @@ app.use(createCleanUI())</code></pre>
         </CuiStack>
       </CuiCardBody>
     </CuiCard>
-
-    <CuiCard>
-      <CuiCardBody>
-        <h2 style="margin-bottom: 0.5rem; font-size: 1.5rem; font-weight: 600;">Scrollbar utility</h2>
-        <p style="font-size: 0.9375rem; color: var(--cui-text-secondary); margin-bottom: 1rem;">
-          Opt in to a persistent, themed scrollbar with the <code class="cui-code">cui-scrollbar</code>
-          class (add <code class="cui-code">cui-scrollbar-thin</code> for a slimmer bar). Useful where
-          the OS hides overlay scrollbars until you scroll — e.g. on macOS. It's not applied by
-          default; add it to any scroll container you choose.
-        </p>
-        <div
-          class="cui-scrollbar"
-          style="max-height: 8rem; overflow-y: auto; border: 1px solid var(--cui-border); border-radius: var(--cui-button-radius); padding: 0.75rem;"
-        >
-          <p v-for="n in 12" :key="n" style="font-size: 0.875rem; margin: 0 0 0.5rem;">
-            Scrollable row {{ n }} — the scrollbar stays visible while this box overflows.
-          </p>
-        </div>
-        <pre class="cui-pre" style="margin-top: 0.75rem;"><code class="cui-code">&lt;div class="cui-scrollbar" style="max-height: 8rem; overflow-y: auto"&gt;…&lt;/div&gt;</code></pre>
-      </CuiCardBody>
-    </CuiCard>
   </CuiStack>
 </template>

--- a/apps/docs/src/pages/Overview.vue
+++ b/apps/docs/src/pages/Overview.vue
@@ -49,6 +49,23 @@ import {
           </CuiFlex>
 
           <CuiFlex align="start" gap="3" wrap="nowrap">
+            <CuiIcon name="rows" size="1.25rem" color="var(--cui-primary)" style="flex-shrink: 0; margin-top: 0.125rem;" />
+            <CuiStack spacing="1" class="min-w-0 flex-1">
+              <h3 style="font-size: 1rem; font-weight: 500;">
+                Global Density
+                <CuiBadge color="primary" size="sm" style="margin-left: 0.375rem; vertical-align: middle;">rare</CuiBadge>
+              </h3>
+              <p style="font-size: 0.875rem; color: var(--cui-text-secondary);">
+                Switch the whole UI between <strong>compact</strong>, <strong>default</strong>, and
+                <strong>comfortable</strong> spacing with one class — like a theme, but for whitespace.
+                Scales padding, gaps, and line-height (never type), with WCAG touch-target floors.
+                Seldom found in other component libraries. See
+                <RouterLink to="/foundations/density" style="color: var(--cui-primary); font-weight: 500;">Density</RouterLink>.
+              </p>
+            </CuiStack>
+          </CuiFlex>
+
+          <CuiFlex align="start" gap="3" wrap="nowrap">
             <CuiIcon name="eye" size="1.25rem" color="var(--cui-primary)" style="flex-shrink: 0; margin-top: 0.125rem;" />
             <CuiStack spacing="1" class="min-w-0 flex-1">
               <h3 style="font-size: 1rem; font-weight: 500;">WCAG AA Accessible</h3>
@@ -215,6 +232,27 @@ app.use(createCleanUI())</code></pre>
             alongside CUI components.
           </p>
         </CuiStack>
+      </CuiCardBody>
+    </CuiCard>
+
+    <CuiCard>
+      <CuiCardBody>
+        <h2 style="margin-bottom: 0.5rem; font-size: 1.5rem; font-weight: 600;">Scrollbar utility</h2>
+        <p style="font-size: 0.9375rem; color: var(--cui-text-secondary); margin-bottom: 1rem;">
+          Opt in to a persistent, themed scrollbar with the <code class="cui-code">cui-scrollbar</code>
+          class (add <code class="cui-code">cui-scrollbar-thin</code> for a slimmer bar). Useful where
+          the OS hides overlay scrollbars until you scroll — e.g. on macOS. It's not applied by
+          default; add it to any scroll container you choose.
+        </p>
+        <div
+          class="cui-scrollbar"
+          style="max-height: 8rem; overflow-y: auto; border: 1px solid var(--cui-border); border-radius: var(--cui-button-radius); padding: 0.75rem;"
+        >
+          <p v-for="n in 12" :key="n" style="font-size: 0.875rem; margin: 0 0 0.5rem;">
+            Scrollable row {{ n }} — the scrollbar stays visible while this box overflows.
+          </p>
+        </div>
+        <pre class="cui-pre" style="margin-top: 0.75rem;"><code class="cui-code">&lt;div class="cui-scrollbar" style="max-height: 8rem; overflow-y: auto"&gt;…&lt;/div&gt;</code></pre>
       </CuiCardBody>
     </CuiCard>
   </CuiStack>

--- a/apps/docs/src/pages/UtilitiesPage.vue
+++ b/apps/docs/src/pages/UtilitiesPage.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { CuiStack, CuiCard, CuiCardBody, CuiCardHeader } from "@itguy614/clean-ui";
+import PropTable from "../components/PropTable.vue";
+import Example from "../components/Example.vue";
+</script>
+
+<template>
+  <CuiStack spacing="8" class="cui-typography">
+    <div>
+      <h1>Utilities</h1>
+      <p class="cui-lead">
+        Opt-in CSS utility classes that aren't components — add them to any element.
+        They're token-driven, so they follow the active theme and density.
+      </p>
+    </div>
+
+    <!-- Scrollbar -->
+    <div>
+      <h2 class="mb-4 text-2xl font-semibold">Scrollbar</h2>
+      <p class="mb-4" style="color: var(--cui-text-secondary);">
+        Add <code class="cui-code">cui-scrollbar</code> to any scroll container to render a
+        persistent, themed scrollbar instead of the operating system's overlay scrollbar (which on
+        macOS hides until you scroll). Add <code class="cui-code">cui-scrollbar-thin</code> for a
+        slimmer bar. It's <strong>not applied by default</strong> — add it where you want it.
+      </p>
+
+      <PropTable
+        :props="[
+          { name: 'cui-scrollbar', type: 'class', default: '—', description: 'Persistent, themed scrollbar on a scroll container (overflow: auto/scroll).' },
+          { name: 'cui-scrollbar-thin', type: 'class', default: '—', description: 'Modifier for a slimmer bar (combine with cui-scrollbar).' },
+        ]"
+      />
+
+      <CuiStack spacing="6" class="mt-6">
+        <Example title="Default" :code="`<div class=&quot;cui-scrollbar&quot; style=&quot;max-height: 8rem; overflow-y: auto&quot;>
+  …content…
+</div>`">
+          <div
+            class="cui-scrollbar"
+            style="max-height: 8rem; overflow-y: auto; border: 1px solid var(--cui-border); border-radius: var(--cui-button-radius); padding: 0.75rem;"
+          >
+            <p v-for="n in 14" :key="n" style="font-size: 0.875rem; margin: 0 0 0.5rem;">
+              Scrollable row {{ n }} — the scrollbar stays visible while this box overflows.
+            </p>
+          </div>
+        </Example>
+
+        <Example title="Thin" :code="`<div class=&quot;cui-scrollbar cui-scrollbar-thin&quot; style=&quot;max-height: 8rem; overflow-y: auto&quot;>
+  …content…
+</div>`">
+          <div
+            class="cui-scrollbar cui-scrollbar-thin"
+            style="max-height: 8rem; overflow-y: auto; border: 1px solid var(--cui-border); border-radius: var(--cui-button-radius); padding: 0.75rem;"
+          >
+            <p v-for="n in 14" :key="n" style="font-size: 0.875rem; margin: 0 0 0.5rem;">
+              Scrollable row {{ n }} — slimmer bar.
+            </p>
+          </div>
+        </Example>
+      </CuiStack>
+
+      <CuiCard variant="outline" class="mt-6">
+        <CuiCardHeader title="Customizing" />
+        <CuiCardBody>
+          <p class="text-sm" style="color: var(--cui-text-secondary);">
+            Override the private custom properties on the element (or a scope) to retheme it:
+          </p>
+          <pre class="cui-pre" style="margin-top: 0.75rem;"><code class="cui-code">.my-panel {
+  --_cui-scrollbar-size: 14px;
+  --_cui-scrollbar-thumb: var(--cui-primary);
+  --_cui-scrollbar-thumb-hover: var(--cui-primary-hover);
+  --_cui-scrollbar-track: var(--cui-surface-bg);
+}</code></pre>
+          <p class="text-sm" style="color: var(--cui-text-secondary); margin-top: 0.75rem;">
+            <strong>How it works:</strong> WebKit/Chromium engines (Chrome, Safari, Edge) get a
+            styled <code class="cui-code">::-webkit-scrollbar</code> — which forces a persistent,
+            non-overlay bar even on macOS. Firefox uses the standard
+            <code class="cui-code">scrollbar-width</code> / <code class="cui-code">scrollbar-color</code>
+            properties. (The two are scoped apart on purpose: setting
+            <code class="cui-code">scrollbar-width</code> makes recent Chromium ignore the
+            <code class="cui-code">::-webkit-scrollbar</code> rules.)
+          </p>
+        </CuiCardBody>
+      </CuiCard>
+    </div>
+
+    <!-- Related -->
+    <CuiCard variant="ghost">
+      <CuiCardBody>
+        <p class="text-sm" style="color: var(--cui-text-secondary);">
+          Looking for text and list helpers (<code class="cui-code">cui-display-1</code>,
+          <code class="cui-code">cui-lead</code>, <code class="cui-code">cui-list-unstyled</code>,
+          <code class="cui-code">cui-list-inline</code>)? Those live on the
+          <RouterLink to="/foundations/typography" style="color: var(--cui-primary); font-weight: 500;">Typography</RouterLink>
+          page.
+        </p>
+      </CuiCardBody>
+    </CuiCard>
+  </CuiStack>
+</template>

--- a/apps/docs/src/router/index.ts
+++ b/apps/docs/src/router/index.ts
@@ -14,6 +14,11 @@ const router = createRouter({
       component: () => import('../pages/Installation.vue'),
     },
     {
+      path: '/changelog',
+      name: 'changelog',
+      component: () => import('../pages/ChangelogPage.vue'),
+    },
+    {
       path: '/foundations/themes',
       name: 'themes',
       component: () => import('../pages/ThemesPage.vue'),

--- a/apps/docs/src/router/index.ts
+++ b/apps/docs/src/router/index.ts
@@ -94,6 +94,11 @@ const router = createRouter({
       component: () => import('../pages/DensityPage.vue'),
     },
     {
+      path: '/foundations/utilities',
+      name: 'utilities',
+      component: () => import('../pages/UtilitiesPage.vue'),
+    },
+    {
       path: '/components/dropdown',
       name: 'dropdown',
       component: () => import('../pages/DropdownPage.vue'),

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -15,4 +15,8 @@ export default defineConfig({
       ),
     },
   },
+  server: {
+    // Allow importing repo-root files (VERSION, CHANGELOG.md) via ?raw in dev.
+    fs: { allow: [resolve(__dirname, "../..")] },
+  },
 });

--- a/packages/clean-ui/src/components/CuiDataGridBulkBar.vue
+++ b/packages/clean-ui/src/components/CuiDataGridBulkBar.vue
@@ -80,7 +80,9 @@ function onAction(action: DataGridBulkAction) {
   align-items: center;
   gap: calc(0.75rem * var(--cui-density-scale, 1));
   padding: calc(0.5rem * var(--cui-density-scale, 1)) calc(0.75rem * var(--cui-density-scale, 1));
-  background: var(--cui-primary);
+  /* Use the solid token (darker in dark mode) so the white text stays readable —
+     plain --cui-primary is lightened in dark mode for accent text/borders. */
+  background: var(--cui-primary-solid, var(--cui-primary));
   color: var(--cui-primary-text);
   border-radius: var(--cui-button-radius, 0.375rem);
   box-shadow: 0 -2px 12px rgb(0 0 0 / 0.15);

--- a/packages/clean-ui/src/styles/main.css
+++ b/packages/clean-ui/src/styles/main.css
@@ -868,3 +868,53 @@
   --cui-density-scale: 1.2;
   --cui-density-gap-scale: 1.12;
 }
+
+/* ============================================================
+   SCROLLBAR UTILITY (opt-in)
+   Add `.cui-scrollbar` to any scroll container to render a
+   persistent, themed scrollbar instead of the OS overlay bar
+   (which on macOS only appears while scrolling). Add
+   `.cui-scrollbar-thin` for a slimmer variant. Tokens are
+   theme-aware and overridable per scope.
+   ============================================================ */
+.cui-scrollbar {
+  --_cui-scrollbar-size: 10px;
+  --_cui-scrollbar-thumb: var(--cui-border);
+  --_cui-scrollbar-thumb-hover: var(--cui-border-strong);
+  --_cui-scrollbar-track: transparent;
+
+  /* Firefox + standard */
+  scrollbar-width: thin;
+  scrollbar-color: var(--_cui-scrollbar-thumb) var(--_cui-scrollbar-track);
+}
+
+.cui-scrollbar-thin {
+  --_cui-scrollbar-size: 6px;
+}
+
+/* WebKit (Chrome / Safari / Edge): defining these forces a persistent
+   bar in place of the macOS overlay scrollbar. */
+.cui-scrollbar::-webkit-scrollbar {
+  width: var(--_cui-scrollbar-size);
+  height: var(--_cui-scrollbar-size);
+}
+
+.cui-scrollbar::-webkit-scrollbar-track {
+  background: var(--_cui-scrollbar-track);
+}
+
+.cui-scrollbar::-webkit-scrollbar-thumb {
+  background: var(--_cui-scrollbar-thumb);
+  border-radius: 9999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+.cui-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: var(--_cui-scrollbar-thumb-hover);
+  background-clip: padding-box;
+}
+
+.cui-scrollbar::-webkit-scrollbar-corner {
+  background: transparent;
+}

--- a/packages/clean-ui/src/styles/main.css
+++ b/packages/clean-ui/src/styles/main.css
@@ -597,11 +597,25 @@
 }
 
 /* --- Lists --- */
+/* Restore list markers — Tailwind's preflight resets ul/ol to list-style: none. */
 .cui-typography ul,
 .cui-typography ol {
   margin-top: 0;
   margin-bottom: var(--cui-paragraph-margin-bottom);
   padding-left: calc(1.5rem * var(--cui-density-scale, 1));
+}
+
+.cui-typography ul {
+  list-style: disc;
+}
+
+.cui-typography ol {
+  list-style: decimal;
+}
+
+/* Nested unordered lists use a hollow marker, as in standard prose. */
+.cui-typography ul ul {
+  list-style: circle;
 }
 
 .cui-typography li {
@@ -882,18 +896,26 @@
   --_cui-scrollbar-thumb: var(--cui-border);
   --_cui-scrollbar-thumb-hover: var(--cui-border-strong);
   --_cui-scrollbar-track: transparent;
-
-  /* Firefox + standard */
-  scrollbar-width: thin;
-  scrollbar-color: var(--_cui-scrollbar-thumb) var(--_cui-scrollbar-track);
 }
 
 .cui-scrollbar-thin {
   --_cui-scrollbar-size: 6px;
 }
 
-/* WebKit (Chrome / Safari / Edge): defining these forces a persistent
-   bar in place of the macOS overlay scrollbar. */
+/* Firefox (and any engine WITHOUT ::-webkit-scrollbar). Scoped here on purpose:
+   when `scrollbar-width` is set, modern Chromium/Edge switch to the standard
+   scrollbar and IGNORE the ::-webkit-scrollbar rules below — which on macOS
+   means the OS overlay bar that hides when idle. Keeping the standard props out
+   of WebKit engines lets the pseudo-elements drive a persistent bar there. */
+@supports not selector(::-webkit-scrollbar) {
+  .cui-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: var(--_cui-scrollbar-thumb) var(--_cui-scrollbar-track);
+  }
+}
+
+/* WebKit / Chromium (Chrome, Safari, Edge): styling these pseudo-elements forces
+   a persistent, non-overlay scrollbar in place of the macOS overlay bar. */
 .cui-scrollbar::-webkit-scrollbar {
   width: var(--_cui-scrollbar-size);
   height: var(--_cui-scrollbar-size);


### PR DESCRIPTION
Four small additions — one library utility, three docs improvements.

## Library
- **`.cui-scrollbar` opt-in utility** (+ `.cui-scrollbar-thin`) — a persistent, theme-aware scrollbar for any scroll container, instead of the OS overlay bar that hides until you scroll (e.g. macOS). Token-driven (`--cui-border` / `--cui-border-strong`), overridable per scope. **Not applied by default** — developers add the class where they want it.

## Docs
- **Changelog page** (Getting Started nav) — renders `CHANGELOG.md` via a small built-in Keep-a-Changelog parser, dogfooding the library's own typography + `CuiCard`/`CuiBadge` (no markdown dependency added). Sourced from the repo file at build via `?raw`.
- **Version badge in the header** — current version from `VERSION` (`?raw`), shown as a `CuiBadge` next to the brand, linking to the changelog.
- **Density callout** on the Overview "Key Features" — flags Global Density as a differentiator (rare in other component libraries), linking to the Density page.
- Scrollbar utility documented with a live demo on the Overview page.

## Notes
- `vite.config.ts` gains `server.fs.allow` for the repo root so the `?raw` imports of `VERSION` / `CHANGELOG.md` resolve in dev. **A running dev server must be restarted** to pick up that config change.
- The version + changelog stay in sync with releases automatically (they read the repo files), so future `/make-release` runs surface on the docs with no extra step.

## Verification
Library build + **349 tests** green; docs `vue-tsc` + `vite build` green; changelog parser validated against the real `CHANGELOG.md` (3 releases, correct sections).