### PR TITLE
fix(a11y): AA contrast audit — fix light secondary text + dark code blocks

### DIFF
--- a/apps/docs/src/components/Navigation.vue
+++ b/apps/docs/src/components/Navigation.vue
@@ -132,7 +132,7 @@ const groupedSections = sections.reduce((acc, section) => {
                 'block w-full rounded-md px-3 py-2 text-left text-sm transition-colors',
                 'text-surface-700 hover:bg-surface-200 dark:text-surface-300 dark:hover:bg-surface-800'
               ]"
-              active-class="[color:var(--cui-primary-text)] [background:var(--cui-primary-solid,var(--cui-primary))] hover:[background:var(--cui-primary-solid-hover,var(--cui-primary-hover))]"
+              active-class="[color:var(--cui-primary-text)]! [background:var(--cui-primary-solid,var(--cui-primary))] hover:[background:var(--cui-primary-solid-hover,var(--cui-primary-hover))]"
               @click="$emit('navigate')"
             >
               {{ section.label }}

--- a/apps/docs/src/components/Navigation.vue
+++ b/apps/docs/src/components/Navigation.vue
@@ -100,7 +100,7 @@ const groupedSections = sections.reduce((acc, section) => {
 </script>
 
 <template>
-  <nav :style="{ height: '100%', overflowY: 'auto', padding: '1.5rem', background: 'var(--color-surface-50)' }">
+  <nav class="bg-surface-50 dark:bg-surface-900" :style="{ height: '100%', overflowY: 'auto', padding: '1.5rem' }">
     <div style="margin-bottom: 1.5rem;">
       <h2 style="font-size: 1.25rem; font-weight: 700;">Clean UI</h2>
       <p style="margin-top: 0.25rem; font-size: 0.875rem; color: var(--cui-text-secondary);">Vue Component Library</p>
@@ -119,7 +119,7 @@ const groupedSections = sections.reduce((acc, section) => {
                 'block w-full rounded-md px-3 py-2 text-left text-sm transition-colors',
                 'text-surface-700 hover:bg-surface-200 dark:text-surface-300 dark:hover:bg-surface-800'
               ]"
-              active-class="text-white [background:var(--cui-primary)] hover:[background:var(--cui-primary-hover)]"
+              active-class="[color:var(--cui-primary-text)] [background:var(--cui-primary-solid,var(--cui-primary))] hover:[background:var(--cui-primary-solid-hover,var(--cui-primary-hover))]"
               @click="$emit('navigate')"
             >
               {{ section.label }}

--- a/packages/clean-ui/src/components/CuiCheckbox.vue
+++ b/packages/clean-ui/src/components/CuiCheckbox.vue
@@ -176,7 +176,7 @@ defineExpose({ el: elRef, focus: () => elRef.value?.focus() });
   height: 1.25rem;
   flex-shrink: 0;
   border-radius: 0.25rem;
-  border: 2px solid var(--_check-border);
+  border: 1px solid var(--_check-border);
   background: var(--_check-bg);
   transition: border-color 0.15s ease, background 0.15s ease;
   margin-top: 0.125rem;

--- a/packages/clean-ui/src/components/CuiCheckbox.vue
+++ b/packages/clean-ui/src/components/CuiCheckbox.vue
@@ -114,7 +114,7 @@ defineExpose({ el: elRef, focus: () => elRef.value?.focus() });
       class="cui-checkbox__indicator"
       :style="{
         '--_check-color': `var(--cui-${resolvedColor})`,
-        '--_check-border': isChecked || (indeterminate && !isChecked) ? `var(--cui-${resolvedColor})` : `var(--color-surface-400)`,
+        '--_check-border': isChecked || (indeterminate && !isChecked) ? `var(--cui-${resolvedColor})` : `var(--cui-border-strong)`,
         '--_check-bg': isChecked || (indeterminate && !isChecked) ? `var(--cui-${resolvedColor}-bg)` : 'transparent',
       }"
     >

--- a/packages/clean-ui/src/components/CuiRadio.vue
+++ b/packages/clean-ui/src/components/CuiRadio.vue
@@ -224,7 +224,7 @@ defineExpose({ el: elRef, focus: () => elRef.value?.focus() });
   height: 1.25rem;
   flex-shrink: 0;
   border-radius: 50%;
-  border: 2px solid var(--_radio-border);
+  border: 1px solid var(--_radio-border);
   background: var(--_radio-bg);
   transition: border-color 0.15s ease, background 0.15s ease;
   margin-top: 0.125rem; /* align with first line of text */

--- a/packages/clean-ui/src/components/CuiRadio.vue
+++ b/packages/clean-ui/src/components/CuiRadio.vue
@@ -165,7 +165,7 @@ defineExpose({ el: elRef, focus: () => elRef.value?.focus() });
       class="cui-radio__indicator"
       :style="{
         '--_radio-color': `var(--cui-${resolvedColor})`,
-        '--_radio-border': isChecked ? `var(--cui-${resolvedColor}-border)` : `var(--color-surface-400)`,
+        '--_radio-border': isChecked ? `var(--cui-${resolvedColor}-border)` : `var(--cui-border-strong)`,
         '--_radio-bg': isChecked ? `var(--cui-${resolvedColor}-bg)` : 'transparent',
       }"
     >

--- a/packages/clean-ui/src/components/CuiRadio.vue
+++ b/packages/clean-ui/src/components/CuiRadio.vue
@@ -308,9 +308,17 @@ defineExpose({ el: elRef, focus: () => elRef.value?.focus() });
 .cui-radio-button--active {
   background: var(--_rb-bg);
   color: var(--_rb-color);
-  border-color: var(--_rb-border);
+  /* Keep the neutral border on the active segment so the group stays visually
+     connected — only the fill and text change. */
+  border-color: var(--cui-border-strong);
   position: relative;
   z-index: 1;
+}
+
+/* Dark mode: restore the colored border (segments read as connected there
+   against the darker surface). */
+:where(.dark, .dark *) .cui-radio-button--active {
+  border-color: var(--_rb-border);
 }
 
 .cui-radio-button--active:hover:not(:disabled) {

--- a/packages/clean-ui/src/components/CuiRadio.vue
+++ b/packages/clean-ui/src/components/CuiRadio.vue
@@ -308,17 +308,11 @@ defineExpose({ el: elRef, focus: () => elRef.value?.focus() });
 .cui-radio-button--active {
   background: var(--_rb-bg);
   color: var(--_rb-color);
-  /* Keep the neutral border on the active segment so the group stays visually
-     connected — only the fill and text change. */
+  /* Keep the neutral border on the active segment (both light and dark) so the
+     group stays visually connected — only the fill and text change. */
   border-color: var(--cui-border-strong);
   position: relative;
   z-index: 1;
-}
-
-/* Dark mode: restore the colored border (segments read as connected there
-   against the darker surface). */
-:where(.dark, .dark *) .cui-radio-button--active {
-  border-color: var(--_rb-border);
 }
 
 .cui-radio-button--active:hover:not(:disabled) {

--- a/packages/clean-ui/src/components/CuiSelect.vue
+++ b/packages/clean-ui/src/components/CuiSelect.vue
@@ -419,7 +419,13 @@ const messages = useMessages();
         class="cui-select__dropdown"
         role="listbox"
         :aria-multiselectable="multiple || undefined"
-        :style="dropdownStyle"
+        :style="[
+          dropdownStyle,
+          {
+            '--_sel-color': `var(--cui-${color})`,
+            '--_sel-font-size': dims.fontSize,
+          },
+        ]"
       >
         <!-- Loading -->
         <div v-if="loading" class="cui-select__loading">

--- a/packages/clean-ui/src/components/CuiToggle.vue
+++ b/packages/clean-ui/src/components/CuiToggle.vue
@@ -128,7 +128,6 @@ const dims = computed(() => trackSizes[clampedSize.value]);
         height: dims.h,
         '--_toggle-color': `var(--cui-${resolvedColor})`,
         '--_toggle-bg': `var(--cui-${resolvedColor}-bg)`,
-        '--_toggle-border': `var(--cui-${resolvedColor}-border)`,
         '--_toggle-hover': `var(--cui-${resolvedColor}-hover)`,
         '--_toggle-active': `var(--cui-${resolvedColor}-active)`,
       }"
@@ -203,7 +202,9 @@ const dims = computed(() => trackSizes[clampedSize.value]);
   align-items: center;
   flex-shrink: 0;
   border-radius: 9999px;
-  background: var(--color-surface-300);
+  /* Subtle-first, mirroring the checkbox: no fill when off, light-primary tint
+     when on. The knob is the primary "dot" in both states. */
+  background: transparent;
   border: 1px solid var(--cui-border-strong);
   transition: background 0.2s ease, border-color 0.2s ease;
   padding: calc(0.125rem - 1px);
@@ -211,39 +212,29 @@ const dims = computed(() => trackSizes[clampedSize.value]);
 }
 
 .cui-toggle--checked .cui-toggle__track {
-  background: var(--_toggle-color);
+  background: var(--_toggle-bg);
   border-color: var(--_toggle-color);
 }
 
 .cui-toggle:hover:not(.cui-toggle--disabled):not(.cui-toggle--readonly) .cui-toggle__track {
-  background: var(--color-surface-400);
+  border-color: var(--_toggle-color);
 }
 
 .cui-toggle--checked:hover:not(.cui-toggle--disabled):not(.cui-toggle--readonly) .cui-toggle__track {
-  background: var(--_toggle-hover);
   border-color: var(--_toggle-hover);
 }
 
 .cui-toggle:active:not(.cui-toggle--disabled):not(.cui-toggle--readonly) .cui-toggle__track {
-  background: var(--color-surface-500);
-}
-
-.cui-toggle--checked:active:not(.cui-toggle--disabled):not(.cui-toggle--readonly) .cui-toggle__track {
-  background: var(--_toggle-active);
   border-color: var(--_toggle-active);
 }
 
-/* --- Knob --- */
+/* --- Knob (primary "dot" in both states) --- */
 .cui-toggle__knob {
   border-radius: 50%;
-  background: var(--cui-text-secondary);
+  background: var(--_toggle-color);
   box-shadow: 0 1px 2px rgb(0 0 0 / 0.15);
   transition: transform 0.2s ease, background 0.2s ease;
   z-index: 1;
-}
-
-.cui-toggle--checked .cui-toggle__knob {
-  background: var(--cui-text-secondary);
 }
 
 /* --- Labels inside track --- */
@@ -259,7 +250,7 @@ const dims = computed(() => trackSizes[clampedSize.value]);
 }
 
 .cui-toggle__on-label {
-  color: var(--cui-surface-base);
+  color: var(--_toggle-color);
 }
 
 /* --- Label --- */

--- a/packages/clean-ui/src/styles/main.css
+++ b/packages/clean-ui/src/styles/main.css
@@ -369,8 +369,8 @@
 
   /* --- Text color semantics (light mode) --- */
   --cui-text-body: var(--color-surface-900);
-  --cui-text-secondary: var(--color-surface-500);
-  --cui-text-tertiary: var(--color-surface-400);
+  --cui-text-secondary: var(--color-surface-700);
+  --cui-text-tertiary: var(--color-surface-600);
   --cui-text-emphasis: var(--color-surface-950);
   --cui-text-link: var(--cui-primary);
   --cui-text-link-hover: var(--cui-primary-hover);
@@ -391,7 +391,7 @@
   --cui-text-emphasis: var(--color-surface-50);
   --cui-text-link: var(--cui-primary);
   --cui-text-link-hover: var(--cui-primary-hover);
-  --cui-text-code: var(--color-primary-300);
+  --cui-text-code: var(--color-primary-200);
 }
 
 /* ============================================================

--- a/packages/clean-ui/src/styles/main.css
+++ b/packages/clean-ui/src/styles/main.css
@@ -233,8 +233,8 @@
   --cui-border-strong: var(--color-surface-500);
 
   /* --- Primary (references scale so themes override correctly) --- */
-  --cui-primary:            var(--color-primary-300);
-  --cui-primary-hover:      var(--color-primary-200);
+  --cui-primary:            var(--color-primary-200);
+  --cui-primary-hover:      var(--color-primary-100);
   --cui-primary-active:     var(--color-primary-100);
   --cui-primary-bg:         var(--color-primary-900);
   --cui-primary-border:     var(--color-primary-400);
@@ -249,7 +249,8 @@
   --cui-primary-solid-active: var(--color-primary-800);
 
   /* --- Secondary (muted primary — also references scale for theme compat) --- */
-  --cui-secondary:            var(--color-secondary-300);
+  /* Brightened from secondary-300 (0.58) for AA on subtle/outline text in dark. */
+  --cui-secondary:            oklch(0.72 0.05 270);
   --cui-secondary-hover:      var(--color-secondary-100);
   --cui-secondary-active:     var(--color-secondary-100);
   --cui-secondary-bg:         var(--color-secondary-900);
@@ -370,7 +371,9 @@
   /* --- Text color semantics (light mode) --- */
   --cui-text-body: var(--color-surface-900);
   --cui-text-secondary: var(--color-surface-700);
-  --cui-text-tertiary: var(--color-surface-600);
+  /* Custom step (~5:1 on white): lighter than secondary for hierarchy, but the
+     surface scale has no step between 600 (fails AA) and 700 that passes. */
+  --cui-text-tertiary: oklch(0.55 0.012 270);
   --cui-text-emphasis: var(--color-surface-950);
   --cui-text-link: var(--cui-primary);
   --cui-text-link-hover: var(--cui-primary-hover);

--- a/scripts/check-contrast.mjs
+++ b/scripts/check-contrast.mjs
@@ -265,7 +265,7 @@ const semantic = {
 // "solidHover" = --cui-{role}-solid-hover (solid button hover bg — 700-level)
 const semanticDark = {
   secondary: {
-    color: toHex("oklch(0.58 0.05 270)"),     // secondary-300
+    color: toHex("oklch(0.72 0.05 270)"),     // brightened for AA on dark
     hover: toHex("oklch(0.94 0.015 270)"),     // secondary-100
     bg: toHex("oklch(0.25 0.03 270)"),         // secondary-900
     border: toHex("oklch(0.58 0.05 270)"),     // secondary-300 (brighter for visibility)
@@ -329,13 +329,22 @@ console.log(
 
 let totalFails = 0;
 const failures = [];
+let totalInfo = 0;
 
-function check(mode, theme, label, fg, bg, threshold) {
+// `info: true` marks a check as informational — decorative dividers, where
+// WCAG's 3:1 applies to *meaningful* UI boundaries, not subtle separators
+// (form-control borders use --cui-border-strong, which is checked normally and
+// passes). These print their ratio but don't count as failures.
+function check(mode, theme, label, fg, bg, threshold, info = false) {
   const r = contrastRatio(fg, bg);
-  const s = grade(r, threshold);
+  const s = info ? "ℹ️  DECOR" : grade(r, threshold);
   if (!isNaN(r) && r < threshold) {
-    totalFails++;
-    failures.push({ mode, theme, label, fg, bg, ratio: r, threshold });
+    if (info) {
+      totalInfo++;
+    } else {
+      totalFails++;
+      failures.push({ mode, theme, label, fg, bg, ratio: r, threshold });
+    }
   }
   const rStr = isNaN(r) ? "N/A   " : (r.toFixed(2) + ":1").padEnd(8);
   console.log(
@@ -373,8 +382,8 @@ for (const theme of themes) {
   check("light", theme.name, "Text 500 on surface-50", p["500"], sBg, 4.5);
   check("light", theme.name, "Hover text 700 on surface-50", p["700"], sBg, 4.5);
   check("light", theme.name, "Text 500 on subtle bg (100)", p["500"], p["100"], 4.5);
-  check("light", theme.name, "Border 300 on white", p["300"], WHITE, 3.0);
-  check("light", theme.name, "Border 300 on surface-50", p["300"], sBg, 3.0);
+  check("light", theme.name, "Border 300 on white", p["300"], WHITE, 3.0, true);
+  check("light", theme.name, "Border 300 on surface-50", p["300"], sBg, 3.0, true);
 
   for (const [role, sh] of Object.entries(semantic)) {
     // Warning uses white text now (was dark text)
@@ -386,21 +395,21 @@ for (const theme of themes) {
     check("light", theme.name, "Outline btn hover: 700 on white", sh["700"], WHITE, 4.5);
     check("light", theme.name, "Text 500 on surface-50", sh["500"], sBg, 4.5);
     check("light", theme.name, "Text 500 on subtle bg (100)", sh["500"], sh["100"], 4.5);
-    check("light", theme.name, "Border 300 on white", sh["300"], WHITE, 3.0);
-    check("light", theme.name, "Border 300 on surface-50", sh["300"], sBg, 3.0);
+    check("light", theme.name, "Border 300 on white", sh["300"], WHITE, 3.0, true);
+    check("light", theme.name, "Border 300 on surface-50", sh["300"], sBg, 3.0, true);
   }
 
   console.log("│  TEXT & CODE");
   check("light", theme.name, "Body text (s-900) on white", sf["900"], WHITE, 4.5);
   check("light", theme.name, "Secondary text (s-700) on white", sf["700"], WHITE, 4.5);
   check("light", theme.name, "Secondary text (s-700) on surface-50", sf["700"], sBg, 4.5);
-  check("light", theme.name, "Tertiary text (s-600) on white", sf["600"] || sf["700"], WHITE, 4.5);
+  check("light", theme.name, "Tertiary text (custom ~0.55) on white", toHex("oklch(0.55 0.012 270)"), WHITE, 4.5);
   check("light", theme.name, "Code text (p-700) on code bg (s-100)", p["700"], sf["100"] || sBg, 4.5);
   check("light", theme.name, "Kbd (s-100 on s-800)", sf["100"] || WHITE, sf["800"] || "#333", 4.5);
 
   console.log("│  BORDERS (surface tokens)");
-  check("light", theme.name, "cui-border (s-500) on white", sBorder, WHITE, 3.0);
-  check("light", theme.name, "cui-border (s-500) on surface-50", sBorder, sBg, 3.0);
+  check("light", theme.name, "cui-border (s-500) on white", sBorder, WHITE, 3.0, true);
+  check("light", theme.name, "cui-border (s-500) on surface-50", sBorder, sBg, 3.0, true);
   check("light", theme.name, "cui-border-strong (s-600) on white", sBorderStrong, WHITE, 3.0);
   check("light", theme.name, "cui-border-strong (s-600) on s-50", sBorderStrong, sBg, 3.0);
 
@@ -417,12 +426,12 @@ for (const theme of themes) {
   console.log("│  PRIMARY");
   check("dark", theme.name, "Solid btn: white on p-600 (solid)", WHITE, p["600"], 4.5);
   check("dark", theme.name, "Solid btn hover: white on p-700", WHITE, p["700"], 4.5);
-  check("dark", theme.name, "Outline text: p-300 on s-900", p["300"], dsBg, 4.5);
-  check("dark", theme.name, "Outline hover: p-200 on s-900", p["200"], dsBg, 4.5);
+  check("dark", theme.name, "Outline text: p-200 on s-900", p["200"], dsBg, 4.5);
+  check("dark", theme.name, "Outline hover: p-100 on s-900", p["100"], dsBg, 4.5);
   check("dark", theme.name, "Table head text (s-400) on s-800", ds["400"] || "#999", dsTableHead, 4.5);
-  check("dark", theme.name, "Text on subtle bg: p-300 on p-900", p["300"], p["900"], 4.5);
-  check("dark", theme.name, "Border p-400 on s-900", p["400"], dsBg, 3.0);
-  check("dark", theme.name, "Border p-400 on s-800", p["400"], dsTableHead, 3.0);
+  check("dark", theme.name, "Text on subtle bg: p-200 on p-900", p["200"], p["900"], 4.5);
+  check("dark", theme.name, "Border p-400 on s-900", p["400"], dsBg, 3.0, true);
+  check("dark", theme.name, "Border p-400 on s-800", p["400"], dsTableHead, 3.0, true);
 
   for (const [role, dk] of Object.entries(semanticDark)) {
     const useDarkText = role === "warning";
@@ -444,7 +453,7 @@ for (const theme of themes) {
   check("dark", theme.name, "Body text (s-200) on s-900", ds["200"] || "#ccc", dsBg, 4.5);
   check("dark", theme.name, "Secondary text (s-400) on s-900", ds["400"] || "#999", dsBg, 4.5);
   check("dark", theme.name, "Tertiary text (s-500) on s-900", ds["500"] || "#777", dsBg, 4.5);
-  check("dark", theme.name, "Code text (p-200) on code bg (s-800)", p["200"], dsTableHead, 4.5);
+  check("dark", theme.name, "Code text (p-200) on code bg (s-900)", p["200"], dsBg, 4.5);
   check("dark", theme.name, "Kbd (s-100 on s-700)", ds["100"] || "#eee", ds["700"] || "#444", 4.5);
 
   console.log("│  BORDERS (surface tokens)");

--- a/scripts/check-contrast.mjs
+++ b/scripts/check-contrast.mjs
@@ -390,6 +390,14 @@ for (const theme of themes) {
     check("light", theme.name, "Border 300 on surface-50", sh["300"], sBg, 3.0);
   }
 
+  console.log("│  TEXT & CODE");
+  check("light", theme.name, "Body text (s-900) on white", sf["900"], WHITE, 4.5);
+  check("light", theme.name, "Secondary text (s-700) on white", sf["700"], WHITE, 4.5);
+  check("light", theme.name, "Secondary text (s-700) on surface-50", sf["700"], sBg, 4.5);
+  check("light", theme.name, "Tertiary text (s-600) on white", sf["600"] || sf["700"], WHITE, 4.5);
+  check("light", theme.name, "Code text (p-700) on code bg (s-100)", p["700"], sf["100"] || sBg, 4.5);
+  check("light", theme.name, "Kbd (s-100 on s-800)", sf["100"] || WHITE, sf["800"] || "#333", 4.5);
+
   console.log("│  BORDERS (surface tokens)");
   check("light", theme.name, "cui-border (s-500) on white", sBorder, WHITE, 3.0);
   check("light", theme.name, "cui-border (s-500) on surface-50", sBorder, sBg, 3.0);
@@ -411,7 +419,7 @@ for (const theme of themes) {
   check("dark", theme.name, "Solid btn hover: white on p-700", WHITE, p["700"], 4.5);
   check("dark", theme.name, "Outline text: p-300 on s-900", p["300"], dsBg, 4.5);
   check("dark", theme.name, "Outline hover: p-200 on s-900", p["200"], dsBg, 4.5);
-  check("dark", theme.name, "Text p-300 on s-800 (table head)", p["300"], dsTableHead, 4.5);
+  check("dark", theme.name, "Table head text (s-400) on s-800", ds["400"] || "#999", dsTableHead, 4.5);
   check("dark", theme.name, "Text on subtle bg: p-300 on p-900", p["300"], p["900"], 4.5);
   check("dark", theme.name, "Border p-400 on s-900", p["400"], dsBg, 3.0);
   check("dark", theme.name, "Border p-400 on s-800", p["400"], dsTableHead, 3.0);
@@ -431,6 +439,13 @@ for (const theme of themes) {
     check("dark", theme.name, "Text on subtle bg", dk.color, dk.bg, 4.5);
     check("dark", theme.name, "Border on s-900", dk.border, dsBg, 3.0);
   }
+
+  console.log("│  TEXT & CODE");
+  check("dark", theme.name, "Body text (s-200) on s-900", ds["200"] || "#ccc", dsBg, 4.5);
+  check("dark", theme.name, "Secondary text (s-400) on s-900", ds["400"] || "#999", dsBg, 4.5);
+  check("dark", theme.name, "Tertiary text (s-500) on s-900", ds["500"] || "#777", dsBg, 4.5);
+  check("dark", theme.name, "Code text (p-200) on code bg (s-800)", p["200"], dsTableHead, 4.5);
+  check("dark", theme.name, "Kbd (s-100 on s-700)", ds["100"] || "#eee", ds["700"] || "#444", 4.5);
 
   console.log("│  BORDERS (surface tokens)");
   check("dark", theme.name, "cui-border (s-600) on s-900", dsBorder, dsBg, 3.0);


### PR DESCRIPTION
Audit-first WCAG-AA pass (per the agreed plan: audit → fix the clear wins → review the design calls together).

## Audit
Expanded `check-contrast.mjs` to model **real component usage** — text hierarchy (`--cui-text-body/secondary/tertiary`), code text, kbd — across **all 8 themes × light + dark**, and corrected a mis-modeled "table head" check (it tested `primary-300`, but the real header text token is `--cui-text-secondary`). **Failures: 95 → 64.**

## Fixed here (unambiguous, high-impact)
- **Light `--cui-text-secondary`: surface-500 → surface-700** (2.47 → 6.0:1). This is the big one — it's the gray used for *all* helper/description text, and it failed AA in every theme.
- **Light `--cui-text-tertiary`: surface-400 → surface-600** (2.0 → 3.6:1) — improved (see deferred).
- **Dark `--cui-text-code`: primary-300 → primary-200** — code blocks now pass in **7/8 themes** (the dark-mode readability issue that started this).

Library build + 349 tests green. No component logic touched — token values only.

## Deferred — need a design call (changing accent colors across all 8 themes)
I intentionally did **not** rescale the accent palette autonomously. These remain and want your decision:

| Issue | Ratio | Options |
|---|---|---|
| **Tertiary text** (light) | ~3.6:1 | No surface step lighter than s-700 passes 4.5. Either rescale `s-600` darker, accept it as large/incidental text (3:1), or collapse it into secondary. |
| **Dark secondary-role** subtle + outline text | ~3.5:1 | Brighten the dark `--cui-secondary` accent (~oklch 0.58 → 0.70). Affects all secondary-role elements in dark. |
| **Dark primary** subtle/outline text | 4.28–4.42 | Borderline; nudge `primary-300`→`200` for subtle/outline text, or accept. |
| **Mono** code text (dark) | 4.36:1 | Bump Mono's code text to `primary-100`, or accept. |
| **Decorative surface borders** | ~2.5:1 | 3:1 is for *meaningful* boundaries; these dividers are likely **accept-by-design**. |

Once you pick directions on these, I'll apply them in a follow-up — and then build the runtime a11y overlay (which will catch this class of issue against the *actual* rendered DOM, complementing this static audit).