### PR TITLE
chore(styles): single-source color scale; remove docs @theme mirror

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@
 - This is a **pnpm** workspace (pnpm ≥ 10). Use `pnpm`, not npm/yarn, for all dev tasks.
 - Build library: `pnpm build` (root) or `pnpm --filter @itguy614/clean-ui build`
 - After rebuild, clear docs cache: `rm -rf apps/docs/node_modules/.vite`
-- Docs app has its own `@theme` in `apps/docs/src/styles/main.css` that must mirror the library's color tokens
+- Color scale (`@theme`) is single-source in `packages/clean-ui/src/styles/theme.css`; both the library `main.css` and the docs `apps/docs/src/styles/main.css` `@import` it (no mirroring). The contrast audit reads the scale from `theme.css` too.
 - Build = `vite build` + `vue-tsc --emitDeclarationOnly`
 
 ## Critical Gotchas

--- a/apps/docs/src/styles/main.css
+++ b/apps/docs/src/styles/main.css
@@ -1,66 +1,9 @@
 @import "tailwindcss";
 
-@theme {
-  /* --- Primary (Indigo-Blue) — full scale --- */
-  --color-primary-50:  oklch(0.97 0.02 270);
-  --color-primary-100: oklch(0.93 0.04 270);
-  --color-primary-200: oklch(0.86 0.08 270);
-  --color-primary-300: oklch(0.74 0.13 270);
-  --color-primary-400: oklch(0.62 0.17 270);
-  --color-primary-500: oklch(0.45 0.18 270);
-  --color-primary-600: oklch(0.40 0.16 270);
-  --color-primary-700: oklch(0.35 0.14 270);
-  --color-primary-800: oklch(0.28 0.11 270);
-  --color-primary-900: oklch(0.22 0.08 270);
-  --color-primary-950: oklch(0.17 0.06 270);
-
-  /* --- Secondary (Muted Indigo, hue 270, low chroma) — condensed --- */
-  --color-secondary-100: oklch(0.94 0.015 270);
-  --color-secondary-300: oklch(0.58 0.05 270);
-  --color-secondary-500: oklch(0.45 0.06 270);
-  --color-secondary-700: oklch(0.35 0.05 270);
-  --color-secondary-900: oklch(0.25 0.03 270);
-
-  /* --- Success (Green, hue 150) — condensed --- */
-  --color-success-100: oklch(0.95 0.04 150);
-  --color-success-300: oklch(0.58 0.12 150);
-  --color-success-500: oklch(0.45 0.14 150);
-  --color-success-700: oklch(0.36 0.12 150);
-  --color-success-900: oklch(0.28 0.08 150);
-
-  /* --- Error (Red, hue 25) — condensed --- */
-  --color-error-100: oklch(0.95 0.04 25);
-  --color-error-300: oklch(0.60 0.14 25);
-  --color-error-500: oklch(0.50 0.20 25);
-  --color-error-700: oklch(0.40 0.16 25);
-  --color-error-900: oklch(0.28 0.10 25);
-
-  /* --- Warning (Amber, hue 80) — condensed --- */
-  --color-warning-100: oklch(0.96 0.04 80);
-  --color-warning-300: oklch(0.62 0.12 80);
-  --color-warning-500: oklch(0.52 0.13 80);
-  --color-warning-700: oklch(0.42 0.12 80);
-  --color-warning-900: oklch(0.30 0.08 80);
-
-  /* --- Info (Cyan, hue 230) — condensed --- */
-  --color-info-100: oklch(0.95 0.03 230);
-  --color-info-300: oklch(0.58 0.10 230);
-  --color-info-500: oklch(0.45 0.13 230);
-  --color-info-700: oklch(0.36 0.10 230);
-  --color-info-900: oklch(0.28 0.07 230);
-
-  /* --- Surface (smooth monotonic scale) — full scale --- */
-  --color-surface-50:  oklch(0.975 0.005 270);
-  --color-surface-100: oklch(0.945 0.005 270);
-  --color-surface-200: oklch(0.900 0.006 270);
-  --color-surface-300: oklch(0.850 0.008 270);
-  --color-surface-400: oklch(0.780 0.008 270);
-  --color-surface-500: oklch(0.720 0.008 270);
-  --color-surface-600: oklch(0.620 0.010 270);
-  --color-surface-700: oklch(0.500 0.010 270);
-  --color-surface-800: oklch(0.380 0.010 270);
-  --color-surface-900: oklch(0.270 0.010 270);
-  --color-surface-950: oklch(0.196 0.010 270);
-}
+/* Color scale (@theme) — imported from the library so the docs compile Tailwind
+   utilities (bg-surface-50, text-primary-500, …) from the exact same tokens.
+   The semantic --cui-* layer + themes arrive at runtime via the library's CSS
+   (pulled in by importing components in main.ts). Never re-declare the scale here. */
+@import "../../../../packages/clean-ui/src/styles/theme.css";
 
 @custom-variant dark (&:where(.dark, .dark *));

--- a/packages/clean-ui/src/styles/main.css
+++ b/packages/clean-ui/src/styles/main.css
@@ -1,74 +1,15 @@
 @import "tailwindcss";
 @import "./themes.css";
+/* Color scale (@theme) — single source of truth, shared with the docs app. */
+@import "./theme.css";
 
 /* ============================================================
    COLOR SYSTEM
    Indigo-blue base, WCAG AA compliant.
+   Color scale lives in ./theme.css (the Tailwind @theme).
+   The semantic --cui-* layer below maps that scale to roles.
    Override any --cui-* token on :root or a container.
    ============================================================ */
-
-@theme {
-  /* --- Primary (Indigo-Blue, hue 270) — full scale for Tailwind utilities --- */
-  --color-primary-50:  oklch(0.97 0.02 270);
-  --color-primary-100: oklch(0.93 0.04 270);
-  --color-primary-200: oklch(0.86 0.08 270);
-  --color-primary-300: oklch(0.74 0.13 270);
-  --color-primary-400: oklch(0.62 0.17 270);
-  --color-primary-500: oklch(0.45 0.18 270);
-  --color-primary-600: oklch(0.40 0.16 270);
-  --color-primary-700: oklch(0.35 0.14 270);
-  --color-primary-800: oklch(0.28 0.11 270);
-  --color-primary-900: oklch(0.22 0.08 270);
-  --color-primary-950: oklch(0.17 0.06 270);
-
-  /* --- Secondary (Muted Indigo, hue 270, low chroma) — condensed --- */
-  --color-secondary-100: oklch(0.94 0.015 270);
-  --color-secondary-300: oklch(0.58 0.05 270);
-  --color-secondary-500: oklch(0.45 0.06 270);
-  --color-secondary-700: oklch(0.35 0.05 270);
-  --color-secondary-900: oklch(0.25 0.03 270);
-
-  /* --- Success (Green, hue 150) — condensed --- */
-  --color-success-100: oklch(0.95 0.04 150);
-  --color-success-300: oklch(0.58 0.12 150);
-  --color-success-500: oklch(0.45 0.14 150);
-  --color-success-700: oklch(0.36 0.12 150);
-  --color-success-900: oklch(0.28 0.08 150);
-
-  /* --- Error (Red, hue 25) — condensed --- */
-  --color-error-100: oklch(0.95 0.04 25);
-  --color-error-300: oklch(0.60 0.14 25);
-  --color-error-500: oklch(0.50 0.20 25);
-  --color-error-700: oklch(0.40 0.16 25);
-  --color-error-900: oklch(0.28 0.10 25);
-
-  /* --- Warning (Amber, hue 80) — condensed --- */
-  --color-warning-100: oklch(0.96 0.04 80);
-  --color-warning-300: oklch(0.62 0.12 80);
-  --color-warning-500: oklch(0.52 0.13 80);
-  --color-warning-700: oklch(0.42 0.12 80);
-  --color-warning-900: oklch(0.30 0.08 80);
-
-  /* --- Info (Cyan, hue 230) — condensed --- */
-  --color-info-100: oklch(0.95 0.03 230);
-  --color-info-300: oklch(0.58 0.10 230);
-  --color-info-500: oklch(0.45 0.13 230);
-  --color-info-700: oklch(0.36 0.10 230);
-  --color-info-900: oklch(0.28 0.07 230);
-
-  /* --- Surface (smooth monotonic scale) — full scale --- */
-  --color-surface-50:  oklch(0.975 0.005 270);
-  --color-surface-100: oklch(0.945 0.005 270);
-  --color-surface-200: oklch(0.900 0.006 270);
-  --color-surface-300: oklch(0.850 0.008 270);
-  --color-surface-400: oklch(0.780 0.008 270);
-  --color-surface-500: oklch(0.720 0.008 270);
-  --color-surface-600: oklch(0.620 0.010 270);
-  --color-surface-700: oklch(0.500 0.010 270);
-  --color-surface-800: oklch(0.380 0.010 270);
-  --color-surface-900: oklch(0.270 0.010 270);
-  --color-surface-950: oklch(0.196 0.010 270);
-}
 
 @custom-variant dark (&:where(.dark, .dark *));
 

--- a/packages/clean-ui/src/styles/theme.css
+++ b/packages/clean-ui/src/styles/theme.css
@@ -1,0 +1,73 @@
+/* ============================================================
+   COLOR SCALE — single source of truth
+   Indigo-blue base, WCAG AA compliant.
+
+   This is the Tailwind `@theme` that generates the color utility
+   classes (bg-surface-50, text-primary-500, …) AND the underlying
+   --color-* custom properties. It is imported by the library's
+   main.css and by the docs app so both compile from the exact same
+   tokens — never mirror these values anywhere else.
+   ============================================================ */
+
+@theme {
+  /* --- Primary (Indigo-Blue, hue 270) — full scale for Tailwind utilities --- */
+  --color-primary-50:  oklch(0.97 0.02 270);
+  --color-primary-100: oklch(0.93 0.04 270);
+  --color-primary-200: oklch(0.86 0.08 270);
+  --color-primary-300: oklch(0.74 0.13 270);
+  --color-primary-400: oklch(0.62 0.17 270);
+  --color-primary-500: oklch(0.45 0.18 270);
+  --color-primary-600: oklch(0.40 0.16 270);
+  --color-primary-700: oklch(0.35 0.14 270);
+  --color-primary-800: oklch(0.28 0.11 270);
+  --color-primary-900: oklch(0.22 0.08 270);
+  --color-primary-950: oklch(0.17 0.06 270);
+
+  /* --- Secondary (Muted Indigo, hue 270, low chroma) — condensed --- */
+  --color-secondary-100: oklch(0.94 0.015 270);
+  --color-secondary-300: oklch(0.58 0.05 270);
+  --color-secondary-500: oklch(0.45 0.06 270);
+  --color-secondary-700: oklch(0.35 0.05 270);
+  --color-secondary-900: oklch(0.25 0.03 270);
+
+  /* --- Success (Green, hue 150) — condensed --- */
+  --color-success-100: oklch(0.95 0.04 150);
+  --color-success-300: oklch(0.58 0.12 150);
+  --color-success-500: oklch(0.45 0.14 150);
+  --color-success-700: oklch(0.36 0.12 150);
+  --color-success-900: oklch(0.28 0.08 150);
+
+  /* --- Error (Red, hue 25) — condensed --- */
+  --color-error-100: oklch(0.95 0.04 25);
+  --color-error-300: oklch(0.60 0.14 25);
+  --color-error-500: oklch(0.50 0.20 25);
+  --color-error-700: oklch(0.40 0.16 25);
+  --color-error-900: oklch(0.28 0.10 25);
+
+  /* --- Warning (Amber, hue 80) — condensed --- */
+  --color-warning-100: oklch(0.96 0.04 80);
+  --color-warning-300: oklch(0.62 0.12 80);
+  --color-warning-500: oklch(0.52 0.13 80);
+  --color-warning-700: oklch(0.42 0.12 80);
+  --color-warning-900: oklch(0.30 0.08 80);
+
+  /* --- Info (Cyan, hue 230) — condensed --- */
+  --color-info-100: oklch(0.95 0.03 230);
+  --color-info-300: oklch(0.58 0.10 230);
+  --color-info-500: oklch(0.45 0.13 230);
+  --color-info-700: oklch(0.36 0.10 230);
+  --color-info-900: oklch(0.28 0.07 230);
+
+  /* --- Surface (smooth monotonic scale) — full scale --- */
+  --color-surface-50:  oklch(0.975 0.005 270);
+  --color-surface-100: oklch(0.945 0.005 270);
+  --color-surface-200: oklch(0.900 0.006 270);
+  --color-surface-300: oklch(0.850 0.008 270);
+  --color-surface-400: oklch(0.780 0.008 270);
+  --color-surface-500: oklch(0.720 0.008 270);
+  --color-surface-600: oklch(0.620 0.010 270);
+  --color-surface-700: oklch(0.500 0.010 270);
+  --color-surface-800: oklch(0.380 0.010 270);
+  --color-surface-900: oklch(0.270 0.010 270);
+  --color-surface-950: oklch(0.196 0.010 270);
+}

--- a/scripts/check-contrast.mjs
+++ b/scripts/check-contrast.mjs
@@ -126,16 +126,18 @@ function buildScale(vars, prefix) {
 }
 
 function parseAllThemes() {
-  const mainCss = readFileSync(
-    resolve(__dirname, "../packages/clean-ui/src/styles/main.css"),
-    "utf-8",
-  );
   const themesCss = readFileSync(
     resolve(__dirname, "../packages/clean-ui/src/styles/themes.css"),
     "utf-8",
   );
+  // The default color scale (@theme) lives in its own single-source file,
+  // imported by both the library and the docs (see theme.css / issue #35).
+  const themeCss = readFileSync(
+    resolve(__dirname, "../packages/clean-ui/src/styles/theme.css"),
+    "utf-8",
+  );
 
-  const themeBlockMatch = mainCss.match(/@theme\s*\{([\s\S]*?)\}/);
+  const themeBlockMatch = themeCss.match(/@theme\s*\{([\s\S]*?)\}/);
   const defaultVars = themeBlockMatch
     ? extractColorVars(themeBlockMatch[1])
     : {};


### PR DESCRIPTION
## What
Extracts the Tailwind color scale (`@theme { --color-* }`) into `packages/clean-ui/src/styles/theme.css` and has **both** the library `main.css` and the docs app `main.css` `@import` it. The duplicated docs `@theme` mirror is removed.

## Why
Tailwind v4 only generates utility classes from `@theme` blocks its compiler scans. The docs previously re-declared the entire scale to get `bg-surface-*` etc., and that copy could silently drift from the library (it caused confusion during #34). One file, one source of truth.

## Changes
- **New** `theme.css` — the `@theme` scale.
- Library `main.css` `@import`s it (inlined at build; dist CSS unchanged for consumers).
- Docs `main.css` `@import`s the same file (relative path) instead of mirroring. Semantic `--cui-*` + themes still load at runtime via the library CSS.
- `scripts/check-contrast.mjs` reads the scale from `theme.css`.
- `CLAUDE.md` note updated.

## Verification
- Library build ✓, docs build ✓ — confirmed the docs output still generates surface/primary utilities **including `dark:` variants** (`dark:bg-surface-900`, `dark:text-surface-300`, …) from the imported scale.
- 349 tests ✓, contrast audit 🎉 all pass.
- The two `@theme` blocks were already value-identical (aligned during #34), so **no visual change** — purely structural.

Closes #35