### PR TITLE
ci: auto-create GitHub Release on publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -10,7 +10,7 @@ on:
       - master
 
 permissions:
-  contents: read
+  contents: write # create GitHub Releases
 
 jobs:
   publish:
@@ -34,6 +34,7 @@ jobs:
         run: |
           NAME=$(node -p "require('./package.json').name")
           VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           if npm view "$NAME@$VERSION" version >/dev/null 2>&1; then
             echo "$NAME@$VERSION is already on npm — skipping publish."
             echo "publish=false" >> "$GITHUB_OUTPUT"
@@ -52,3 +53,26 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.check.outputs.version }}
+        run: |
+          TAG="v$VERSION"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — skipping."
+            exit 0
+          fi
+          # Extract this version's section from CHANGELOG.md (between its
+          # heading and the next "## [" heading) to use as the release notes.
+          awk -v ver="$VERSION" '
+            $0 ~ ("^## \\[" ver "\\]") {flag=1; next}
+            flag && /^## \[/ {exit}
+            flag {print}
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "See CHANGELOG.md for details." > release-notes.md
+          fi
+          gh release create "$TAG" --title "$TAG" --notes-file release-notes.md


### PR DESCRIPTION
Automates the GitHub Release step that was manual for v1.0.0.

After the `Publish to npm` workflow publishes a new version on master push, it now also creates the `v<version>` GitHub Release, with notes pulled from that version's section of `CHANGELOG.md`.\n\n- Gated on the same `publish == true` (version-is-new) check, so ordinary master pushes / re-runs don't create releases.\n- **Idempotent:** skips if the `v<version>` release already exists.\n- Bumps workflow `permissions` to `contents: write` (required to create releases); uses the default `GITHUB_TOKEN`.\n- Changelog extraction verified locally against the real `[1.0.0]` / `[0.9.0]` sections (correct content, stops at the next heading).\n\nCloses #39