### PR TITLE
fix(data-grid): subtle bulk-action bar (no more blue-on-blue buttons)

### DIFF
--- a/packages/clean-ui/src/components/CuiDataGridBulkBar.vue
+++ b/packages/clean-ui/src/components/CuiDataGridBulkBar.vue
@@ -80,10 +80,12 @@ function onAction(action: DataGridBulkAction) {
   align-items: center;
   gap: calc(0.75rem * var(--cui-density-scale, 1));
   padding: calc(0.5rem * var(--cui-density-scale, 1)) calc(0.75rem * var(--cui-density-scale, 1));
-  /* Use the solid token (darker in dark mode) so the white text stays readable —
-     plain --cui-primary is lightened in dark mode for accent text/borders. */
-  background: var(--cui-primary-solid, var(--cui-primary));
-  color: var(--cui-primary-text);
+  /* Subtle-first (per the library's guiding principle): a tinted primary surface
+     rather than a solid hero-color background, so the outline action buttons keep
+     full contrast. All three slots auto-swap for dark mode. */
+  background: var(--cui-primary-bg);
+  border: 1px solid var(--cui-primary-border);
+  color: var(--cui-primary);
   border-radius: var(--cui-button-radius, 0.375rem);
   box-shadow: 0 -2px 12px rgb(0 0 0 / 0.15);
   max-width: 48rem;


### PR DESCRIPTION
Fixes the low-contrast bulk-action bar: the bar used a solid `--cui-primary` background with outline-primary buttons, rendering them blue-on-blue at rest.

**Fix:** re-theme the bar as a tinted primary surface (`--cui-primary-bg` + `--cui-primary-border` + `--cui-primary` text). The existing outline-primary action buttons now read with full contrast, and the destructive (red solid) button is unaffected. This also brings the bar in line with the library's "subtle by default, bold by choice" principle — a solid hero-color background was itself a deviation.

- Dark mode: all three slots auto-swap; the resulting text/bg pairing is the `p-200 on p-900` combo the contrast audit already validates.
- Build + 349 tests green.

Reviewer note: please eyeball the bar in light & dark across a couple themes (Navy/Azure) to confirm the tinted look reads well.

Closes #49