### PR TITLE
fix(badge/button/alert): clarify variant vs color (dev warning + docs)

### DIFF
--- a/apps/docs/src/pages/AlertPage.vue
+++ b/apps/docs/src/pages/AlertPage.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from "vue";
-import { CuiAlert, CuiButton, CuiFlex, CuiStack } from "@itguy614/clean-ui";
+import { CuiAlert, CuiButton, CuiCard, CuiCardBody, CuiFlex, CuiStack } from "@itguy614/clean-ui";
 import PropTable from "../components/PropTable.vue";
 import EventTable from "../components/EventTable.vue";
 import Example from "../components/Example.vue";
@@ -23,6 +23,22 @@ const showPulse = ref(true);
         animations, persistent attention effects, dismissible and auto-dismiss.
       </p>
     </div>
+
+    <CuiCard variant="outline">
+      <CuiCardBody>
+        <p class="text-sm text-surface-700 dark:text-surface-300">
+          <strong><code>color</code> vs <code>variant</code>:</strong>
+          <code>color</code> sets the semantic role (<code>primary</code>,
+          <code>success</code>, <code>error</code>, <code>warning</code>,
+          <code>info</code>, …); <code>variant</code> sets the visual style
+          (<code>solid</code>, <code>subtle</code>, <code>outline</code>).
+          Passing a role name to <code>variant</code> (e.g.
+          <code>variant="danger"</code>) won't work — use
+          <code>color="error"</code> (the role for “danger” is
+          <code>error</code>).
+        </p>
+      </CuiCardBody>
+    </CuiCard>
 
     <div>
       <h2 class="mb-4 text-2xl font-semibold">Props</h2>

--- a/apps/docs/src/pages/BadgePage.vue
+++ b/apps/docs/src/pages/BadgePage.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from "vue";
-import { CuiBadge, CuiButton, CuiFlex, CuiInput, CuiStack } from "@itguy614/clean-ui";
+import { CuiBadge, CuiButton, CuiCard, CuiCardBody, CuiFlex, CuiInput, CuiStack } from "@itguy614/clean-ui";
 import PropTable from "../components/PropTable.vue";
 import EventTable from "../components/EventTable.vue";
 import Example from "../components/Example.vue";
@@ -26,6 +26,22 @@ function resetTags() {
         Supports animations for attention-grabbing feedback.
       </p>
     </div>
+
+    <CuiCard variant="outline">
+      <CuiCardBody>
+        <p class="text-sm text-surface-700 dark:text-surface-300">
+          <strong><code>color</code> vs <code>variant</code>:</strong>
+          <code>color</code> sets the semantic role (<code>primary</code>,
+          <code>success</code>, <code>error</code>, <code>warning</code>,
+          <code>info</code>, …); <code>variant</code> sets the visual style
+          (<code>solid</code>, <code>subtle</code>, <code>outline</code>).
+          Passing a role name to <code>variant</code> (e.g.
+          <code>variant="info"</code>) won't color the badge — use
+          <code>color="info"</code>. Note the role for “danger” is
+          <code>error</code>.
+        </p>
+      </CuiCardBody>
+    </CuiCard>
 
     <div>
       <h2 class="mb-4 text-2xl font-semibold">Props</h2>

--- a/apps/docs/src/pages/ButtonPage.vue
+++ b/apps/docs/src/pages/ButtonPage.vue
@@ -25,6 +25,22 @@ function simulateLoad() {
       </p>
     </div>
 
+    <CuiCard variant="outline">
+      <CuiCardBody>
+        <p class="text-sm text-surface-700 dark:text-surface-300">
+          <strong><code>color</code> vs <code>variant</code>:</strong>
+          <code>color</code> sets the semantic role (<code>primary</code>,
+          <code>success</code>, <code>error</code>, <code>warning</code>,
+          <code>info</code>, …); <code>variant</code> sets the visual style
+          (<code>solid</code>, <code>outline</code>, <code>dash</code>,
+          <code>ghost</code>). Passing a role name to <code>variant</code> (e.g.
+          <code>variant="primary"</code>) won't work — use
+          <code>color="primary"</code>. Note the role for “danger” is
+          <code>error</code>.
+        </p>
+      </CuiCardBody>
+    </CuiCard>
+
     <div>
       <h2 class="mb-4 text-2xl font-semibold">Props</h2>
       <PropTable

--- a/packages/clean-ui/src/components/CuiAlert.vue
+++ b/packages/clean-ui/src/components/CuiAlert.vue
@@ -4,6 +4,7 @@ import type { HideableProps, ColorableProps, CuiRounded, LiveRegionProps } from 
 import CuiIcon from "./CuiIcon.vue";
 import { COLOR_ICON_MAP } from "../utils/colorIconMap";
 import { resolveLiveRegion } from "../utils/liveRegion";
+import { warnVariantColor } from "../utils/devWarn";
 import { useMessages } from "../composables/useMessages";
 
 const radiusMap: Record<CuiRounded, string> = {
@@ -47,6 +48,8 @@ const props = withDefaults(defineProps<CuiAlertProps>(), {
   hidden: false,
   rounded: "md",
 });
+
+warnVariantColor("CuiAlert", { value: props.variant, allowed: ["solid", "subtle", "outline"] }, props.color);
 
 const emit = defineEmits<{
   dismiss: [];

--- a/packages/clean-ui/src/components/CuiBadge.vue
+++ b/packages/clean-ui/src/components/CuiBadge.vue
@@ -2,6 +2,7 @@
 import { computed } from "vue";
 import type { ColorableProps, SizeableProps, HideableProps, CuiRounded } from "../types/common";
 import { clampSize } from "../utils/sizing";
+import { warnVariantColor } from "../utils/devWarn";
 import CuiIcon from "./CuiIcon.vue";
 import { useMessages } from "../composables/useMessages";
 
@@ -33,6 +34,8 @@ const props = withDefaults(defineProps<CuiBadgeProps>(), {
   rounded: "full",
   hidden: false,
 });
+
+warnVariantColor("CuiBadge", { value: props.variant, allowed: ["solid", "subtle", "outline"] }, props.color);
 
 const radiusMap: Record<CuiRounded, string> = {
   none: "0",

--- a/packages/clean-ui/src/components/CuiButton.vue
+++ b/packages/clean-ui/src/components/CuiButton.vue
@@ -3,6 +3,7 @@ import { computed, ref, useTemplateRef } from "vue";
 import type { Component } from "vue";
 import CuiIcon from "./CuiIcon.vue";
 import { BUTTON_SIZE_SCALE } from "../utils/sizing";
+import { warnVariantColor } from "../utils/devWarn";
 import type {
   CuiColor,
   CuiRounded,
@@ -43,6 +44,8 @@ const props = withDefaults(defineProps<CuiButtonProps>(), {
   disabled: false,
   hidden: false,
 });
+
+warnVariantColor("CuiButton", { value: props.variant, allowed: ["solid", "outline", "dash", "ghost"] }, props.color);
 
 const isDisabled = computed(() => props.disabled || props.loading);
 

--- a/packages/clean-ui/src/utils/__tests__/devWarn.test.ts
+++ b/packages/clean-ui/src/utils/__tests__/devWarn.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { warnVariantColor } from "../devWarn";
+
+const BADGE_VARIANTS = ["solid", "subtle", "outline"] as const;
+
+describe("warnVariantColor", () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it("is silent for valid variant + color", () => {
+    warnVariantColor("CuiBadge", { value: "subtle", allowed: BADGE_VARIANTS }, "primary");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("flags a color name passed to variant and points at the color prop", () => {
+    warnVariantColor("CuiBadge", { value: "info", allowed: BADGE_VARIANTS }, "primary");
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain('variant="info" is not valid');
+    expect(warn.mock.calls[0][0]).toContain(`did you mean color="info"?`);
+  });
+
+  it("flags an unknown variant without a color hint", () => {
+    warnVariantColor("CuiButton", { value: "zzbogus", allowed: BADGE_VARIANTS }, "primary");
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain('variant="zzbogus" is not valid');
+    expect(warn.mock.calls[0][0]).not.toContain("did you mean");
+  });
+
+  it("flags an invalid color role and suggests error for danger", () => {
+    warnVariantColor("CuiAlert", { value: "subtle", allowed: BADGE_VARIANTS }, "danger");
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain('color="danger" is not a valid role');
+    expect(warn.mock.calls[0][0]).toContain(`Use color="error".`);
+  });
+
+  it("flags an arbitrary invalid color without the danger alias", () => {
+    warnVariantColor("CuiAlert", { value: "subtle", allowed: BADGE_VARIANTS }, "turquoise");
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain('color="turquoise" is not a valid role');
+    expect(warn.mock.calls[0][0]).not.toContain(`Use color="error".`);
+  });
+
+  it("warns only once for a repeated identical message", () => {
+    warnVariantColor("CuiBadge", { value: "qqrepeat", allowed: BADGE_VARIANTS }, "primary");
+    warnVariantColor("CuiBadge", { value: "qqrepeat", allowed: BADGE_VARIANTS }, "primary");
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/clean-ui/src/utils/devWarn.ts
+++ b/packages/clean-ui/src/utils/devWarn.ts
@@ -1,0 +1,51 @@
+import { isColorRole } from "./color";
+
+const ROLE_LIST =
+  "primary, secondary, success, error, warning, info, surface, surface-light, surface-dark";
+
+// Warn at most once per unique message, so the same mistake repeated across many
+// component instances doesn't spam the console. (Matches the unconditional
+// console.warn pattern already used by CuiIcon — reliable NODE_ENV/dev detection
+// across bundlers in a published ESM library is brittle, and these only ever fire
+// on genuine misuse, never on valid usage.)
+const warned = new Set<string>();
+function warnOnce(message: string): void {
+  if (warned.has(message)) return;
+  warned.add(message);
+  console.warn(message);
+}
+
+/**
+ * Sanity-check the two most-confused props. `color` sets the semantic role;
+ * `variant` sets the structural style — passing a role name to `variant`
+ * (e.g. `variant="info"`) is the common mistake, so we detect it and point at
+ * the right prop. Only warns on invalid values; valid usage is silent.
+ *
+ * @param component  Display name, e.g. "CuiBadge".
+ * @param variant    The value passed to `variant` + that component's allowed set.
+ * @param color      The value passed to `color` (validated against the roles).
+ */
+export function warnVariantColor(
+  component: string,
+  variant: { value: string | undefined; allowed: readonly string[] },
+  color: string | undefined,
+): void {
+  const v = variant.value;
+  if (v != null && !variant.allowed.includes(v)) {
+    const hint = isColorRole(v)
+      ? ` "${v}" is a color role — did you mean color="${v}"?`
+      : "";
+    warnOnce(
+      `[clean-ui] ${component}: variant="${v}" is not valid. ` +
+        `Expected one of: ${variant.allowed.join(", ")}.${hint}`,
+    );
+  }
+
+  if (color != null && !isColorRole(color)) {
+    const alias = color === "danger" ? ` Use color="error".` : "";
+    warnOnce(
+      `[clean-ui] ${component}: color="${color}" is not a valid role. ` +
+        `Expected one of: ${ROLE_LIST}.${alias}`,
+    );
+  }
+}


### PR DESCRIPTION
## Context
#48 reported that variant prop types don't match runtime-accepted values. On investigation, **the types are correct** — clean-ui intentionally separates `color` (semantic role) from `variant` (structural style), and the runtime does *not* accept role names on `variant` (it silently falls back). The report conflated the two props and used `danger` (the role here is `error`). So the issue's suggested fix (adding role names to the variant union) would have been wrong.

## What this does instead
Keeps the correct types and removes the confusion at the source:

- **`warnVariantColor()`** (`utils/devWarn.ts`) — warns when an unrecognized `variant`/`color` is passed. When the bad `variant` value is actually a color role, it points at the right prop: *“variant=\"info\" is not valid … \"info\" is a color role — did you mean color=\"info\"?”*. Special-cases `danger → error`. Deduped (warn-once per message) so it never spams. Wired into `CuiBadge`, `CuiButton`, `CuiAlert`.
- **Docs:** a concise “color vs variant” callout on the Badge / Button / Alert pages.
- **Tests:** 6 unit tests for the helper.

## Note on the dev guard
Reliable NODE_ENV/dev detection across bundlers in a published ESM lib is brittle (Vite freezes `import.meta.env.DEV` at lib-build; a `typeof process` guard won't fire in Vite browser consumers). The warning is therefore unconditional — matching the existing `CuiIcon` precedent — but it only ever fires on **genuine misuse**, never on valid usage, and is deduped.

Build + docs build + 355 tests green.

Closes #48