### PR TITLE
fix(input): type=number/range + numeric modelValue

### DIFF
--- a/packages/clean-ui/src/components/CuiInput.vue
+++ b/packages/clean-ui/src/components/CuiInput.vue
@@ -13,11 +13,19 @@ const radiusMap: Record<CuiRounded, string> = {
   full: "9999px",
 };
 
-export type InputType = "text" | "password" | "email" | "url" | "tel" | "search";
+export type InputType =
+  | "text"
+  | "password"
+  | "email"
+  | "url"
+  | "tel"
+  | "search"
+  | "number"
+  | "range";
 
 export interface CuiInputProps extends HideableProps, ColorableProps, SizeableProps, DisableableProps {
-  /** v-model binding */
-  modelValue?: string;
+  /** v-model binding. `string | number` so `type="number"` / `v-model.number` bind without a cast. */
+  modelValue?: string | number;
   /** Input type */
   type?: InputType;
   /** Placeholder text */
@@ -48,7 +56,7 @@ const props = withDefaults(defineProps<CuiInputProps>(), {
 });
 
 const emit = defineEmits<{
-  "update:modelValue": [value: string];
+  "update:modelValue": [value: string | number];
   clear: [];
 }>();
 
@@ -61,7 +69,15 @@ const resolvedType = computed(() => {
 });
 
 // Clearable logic
-const showClear = computed(() => props.clearable && props.modelValue && !props.disabled && !props.readonly);
+// Use an explicit emptiness check (not truthiness) so a numeric 0 still shows the clear button.
+const showClear = computed(
+  () =>
+    props.clearable &&
+    props.modelValue !== "" &&
+    props.modelValue != null &&
+    !props.disabled &&
+    !props.readonly,
+);
 
 function clear() {
   emit("update:modelValue", "");

--- a/packages/clean-ui/src/components/__tests__/CuiInput.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiInput.test.ts
@@ -58,4 +58,18 @@ describe("CuiInput", () => {
     });
     expect(wrapper.find("button.cui-input__clear").exists()).toBe(false);
   });
+
+  it("accepts type='number' and a numeric modelValue", () => {
+    const wrapper = mount(CuiInput, { props: { type: "number", modelValue: 42 } });
+    const native = wrapper.get("input.cui-input__native");
+    expect(native.attributes("type")).toBe("number");
+    expect((native.element as HTMLInputElement).value).toBe("42");
+  });
+
+  it("shows the clear button for a numeric 0 (not treated as empty)", () => {
+    const wrapper = mount(CuiInput, {
+      props: { type: "number", modelValue: 0, clearable: true },
+    });
+    expect(wrapper.find("button.cui-input__clear").exists()).toBe(true);
+  });
 });


### PR DESCRIPTION
Fixes the two TS errors when using `CuiInput` for numeric fields.

- **`InputType`:** add `number` and `range`. (`tel`/`search` were already in the union; only `number` was actually missing per the report — `range` added per the chosen scope.)
- **`modelValue` + `update:modelValue`:** widened to `string | number`, so `type="number"` and `v-model.number` bind without casting.
- **`showClear`:** switched from a truthiness check to an explicit emptiness check (`!== "" && != null`), so a numeric `0` still shows the clear button (it previously would have been hidden).

```vue
<CuiInput v-model.number="config.port" type="number" :min="1024" :max="65535" />
```
now type-checks.

Added tests for numeric `modelValue` and the `0`-value clear button. Build + 351 tests green.

Closes #47