### PR TITLE
fix(table): header divider for CuiDataGrid (td-based headers)

### DIFF
--- a/packages/clean-ui/src/components/CuiTable.vue
+++ b/packages/clean-ui/src/components/CuiTable.vue
@@ -169,6 +169,15 @@ defineExpose({ scrollWrapper });
   background: var(--color-surface-800);
 }
 
+/* CuiDataGrid renders td-based header cells (CuiTableCell) inside <thead>, which
+   the th-only rule above can't match — so the header→body divider was missing on
+   the DataGrid. Give td headers the same divider. (Only the border: DataGrid pins
+   its header at the cell level via headerCellStyle, so we deliberately do NOT add
+   a sticky position rule for td here — that would re-create the nested-sticky bug.) */
+.cui-table thead td {
+  border-bottom: 1px solid var(--cui-border);
+}
+
 /* --- Body row dividers (on cells, not rows, for border-separate compat) --- */
 .cui-table tbody td {
   border-bottom: 1px solid var(--cui-border);


### PR DESCRIPTION
`CuiDataGrid` had no line separating the header row from the body, while a plain `CuiTable` did.

## Cause
The divider is drawn by `.cui-table thead th { border-bottom }`, but `CuiDataGrid` renders **td-based** header cells (`CuiTableCell`) inside `<thead>`, which the th-only selector can't match.

## Fix
Add `.cui-table thead td { border-bottom: 1px solid var(--cui-border); }`.

**Only the divider is extended — deliberately not the sticky-position rule.** The DataGrid pins its header at the cell level via `headerCellStyle`; adding a `thead`-level `position: sticky` for `td` would re-create the nested same-axis sticky detach bug fixed in #22.

CSS-only; jsdom can't assert the rendered border, so please eyeball a DataGrid (sticky + non-sticky, light + dark) to confirm the divider shows. Build + 349 tests green.

Closes #43