### PR TITLE
fix(tabs): scroll the tab bar when tabs overflow their container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- `CuiTabs` tab bar now scrolls when the tabs overflow their container, with an edge fade marking the clipped side — trailing tabs were previously clipped and unreachable inside `CuiModal` / `CuiSlideover` (#57)
+- `CuiTabs` keyboard navigation no longer focuses a tab in a different `CuiTabs` instance when two tab sets on a page share tab values (#57)
+
 ## [1.0.1] - 2026-06-29
 
 ### Added

--- a/apps/docs/src/pages/TabsPage.vue
+++ b/apps/docs/src/pages/TabsPage.vue
@@ -7,6 +7,8 @@ import {
   CuiFormField,
   CuiIcon,
   CuiInput,
+  CuiSlideover,
+  CuiSlider,
   CuiStack,
   CuiTab,
   CuiTabs,
@@ -24,6 +26,20 @@ const closeable = ref("file1");
 const closeableTabs = ref(["file1", "file2", "file3"]);
 const transitionTab = ref("fade");
 const lazyTab = ref("tab1");
+
+const overflowTabs = [
+  { value: "general", label: "General" },
+  { value: "notifications", label: "Notifications" },
+  { value: "appearance", label: "Appearance" },
+  { value: "integrations", label: "Integrations" },
+  { value: "billing", label: "Billing & Invoices" },
+  { value: "advanced", label: "Advanced" },
+];
+const overflow = ref("general");
+const overflowWidth = ref(343);
+const overflowVariant = ref<"underline" | "segmented">("underline");
+const slideoverOpen = ref(false);
+const slideoverTab = ref("general");
 
 function removeTab(value: string) {
   closeableTabs.value = closeableTabs.value.filter((t) => t !== value);
@@ -307,6 +323,98 @@ function resetTabs() {
               </CuiTab>
             </CuiTabs>
             <p class="text-sm text-surface-500">Panels are destroyed when inactive (v-if instead of v-show). Good for deferring expensive renders or data fetches.</p>
+          </CuiStack>
+        </Example>
+
+        <!-- Overflow -->
+        <Example title="Overflow in narrow containers" :code="`<!-- Nothing to configure — the tab bar scrolls when the tabs don't fit -->
+<div style=&quot;width: 343px&quot;>
+  <CuiTabs v-model=&quot;active&quot;>
+    <CuiTab value=&quot;general&quot; label=&quot;General&quot;>…</CuiTab>
+    <CuiTab value=&quot;notifications&quot; label=&quot;Notifications&quot;>…</CuiTab>
+    <!-- …more tabs than fit… -->
+  </CuiTabs>
+</div>`">
+          <CuiStack spacing="4">
+            <p class="text-sm text-surface-500">
+              When the tabs are wider than their container the bar scrolls horizontally, and the
+              clipped edge fades to show there's more. Drag the width to see it engage — the active
+              tab is always scrolled into view.
+            </p>
+
+            <CuiSlider
+              v-model="overflowWidth"
+              label="Container width"
+              :min="240"
+              :max="720"
+              :step="1"
+              show-value
+              :format-value="(v: number) => `${v}px`"
+            />
+
+            <div
+              class="rounded-lg border border-dashed p-3"
+              style="border-color: var(--cui-border)"
+              :style="{ width: `${overflowWidth}px`, maxWidth: '100%' }"
+            >
+              <CuiTabs v-model="overflow" :variant="overflowVariant">
+                <CuiTab
+                  v-for="tab in overflowTabs"
+                  :key="tab.value"
+                  :value="tab.value"
+                  :label="tab.label"
+                >
+                  <p>{{ tab.label }} panel.</p>
+                </CuiTab>
+              </CuiTabs>
+            </div>
+
+            <CuiFlex gap="4" align="center" wrap="wrap">
+              <CuiToggle
+                :model-value="overflowVariant === 'segmented'"
+                label="Segmented variant"
+                @update:model-value="overflowVariant = $event ? 'segmented' : 'underline'"
+              />
+              <CuiButton
+                size="sm"
+                @click="overflow = overflowTabs[overflowTabs.length - 1].value"
+              >
+                Activate last tab
+              </CuiButton>
+            </CuiFlex>
+          </CuiStack>
+        </Example>
+
+        <!-- Overflow inside a clipping overlay -->
+        <Example title="Overflow inside a Slideover" :code="`<CuiSlideover v-model:visible=&quot;open&quot; title=&quot;Settings&quot; size=&quot;sm&quot;>
+  <CuiTabs v-model=&quot;active&quot;>
+    <!-- Tabs stay reachable even though the panel is overflow: hidden -->
+  </CuiTabs>
+</CuiSlideover>`">
+          <CuiStack spacing="3">
+            <p class="text-sm text-surface-500">
+              The original bug report: overlay panels are
+              <code class="cui-code">overflow: hidden</code>, so
+              before this fix the trailing tabs were clipped away with no way to reach them.
+            </p>
+            <div>
+              <CuiButton @click="slideoverOpen = true">
+                <template #prefix><CuiIcon name="sidebar" /></template>
+                Open settings panel
+              </CuiButton>
+            </div>
+            <CuiSlideover v-model:visible="slideoverOpen" title="Settings" size="sm">
+              <CuiTabs v-model="slideoverTab">
+                <CuiTab
+                  v-for="tab in overflowTabs"
+                  :key="tab.value"
+                  :value="tab.value"
+                  :label="tab.label"
+                >
+                  <p>{{ tab.label }} settings go here.</p>
+                </CuiTab>
+              </CuiTabs>
+            </CuiSlideover>
           </CuiStack>
         </Example>
 

--- a/packages/clean-ui/src/components/CuiTabs.vue
+++ b/packages/clean-ui/src/components/CuiTabs.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, provide, toRef, computed, nextTick } from "vue";
+import { ref, provide, toRef, computed, nextTick, onMounted, onBeforeUnmount } from "vue";
 import CuiIcon from "./CuiIcon.vue";
 import {
   TabsContextKey,
@@ -41,6 +41,7 @@ const emit = defineEmits<{
 const activeTab = ref(props.modelValue ?? "");
 const previousTab = ref("");
 const tabs = ref<TabDefinition[]>([]);
+const barRef = ref<HTMLElement | null>(null);
 
 // Sync external v-model
 import { watch } from "vue";
@@ -124,13 +125,73 @@ function onKeydown(e: KeyboardEvent) {
   if (nextIdx >= 0) {
     activate(enabledTabs[nextIdx].value);
     nextTick(() => {
-      const tabEl = document.querySelector<HTMLElement>(
-        `[data-cui-tab-value="${enabledTabs[nextIdx].value}"]`,
-      );
-      tabEl?.focus();
+      tabElement(enabledTabs[nextIdx].value)?.focus();
     });
   }
 }
+
+// --- Overflow scrolling ---
+// The bar scrolls when the tabs don't fit; without this the trailing tabs are
+// clipped by any `overflow: hidden` ancestor (Modal/Slideover) and unreachable.
+
+/** Scoped lookup — a global querySelector would hit another CuiTabs on the page. */
+function tabElement(value: string): HTMLElement | null {
+  return barRef.value?.querySelector<HTMLElement>(`[data-cui-tab-value="${value}"]`) ?? null;
+}
+
+/** Which edges have content scrolled out of view — drives the edge fade mask. */
+const overflowEdges = ref<"none" | "start" | "end" | "both">("none");
+
+function updateOverflow() {
+  const el = barRef.value;
+  if (!el) return;
+  const horizontal = props.orientation === "horizontal";
+  const viewport = horizontal ? el.clientWidth : el.clientHeight;
+  const content = horizontal ? el.scrollWidth : el.scrollHeight;
+  // Math.abs: RTL scrollLeft is negative in some engines
+  const pos = Math.abs(horizontal ? el.scrollLeft : el.scrollTop);
+
+  // 1px tolerance absorbs sub-pixel layout rounding
+  if (content - viewport <= 1) {
+    overflowEdges.value = "none";
+    return;
+  }
+  const atStart = pos <= 1;
+  const atEnd = pos >= content - viewport - 1;
+  overflowEdges.value = atStart ? "end" : atEnd ? "start" : "both";
+}
+
+function scrollActiveIntoView() {
+  // Keyboard nav scrolls via focus(); this covers v-model changes and mount.
+  tabElement(activeTab.value)?.scrollIntoView?.({ inline: "nearest", block: "nearest" });
+}
+
+let resizeObserver: ResizeObserver | undefined;
+
+onMounted(() => {
+  nextTick(() => {
+    scrollActiveIntoView();
+    updateOverflow();
+  });
+  if (typeof ResizeObserver !== "undefined" && barRef.value) {
+    resizeObserver = new ResizeObserver(updateOverflow);
+    resizeObserver.observe(barRef.value);
+  }
+});
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect();
+  resizeObserver = undefined;
+});
+
+watch(activeTab, () => {
+  scrollActiveIntoView();
+  updateOverflow();
+}, { flush: "post" });
+
+// Tabs registering/unregistering changes the scrollable width
+watch(() => tabs.value.length, updateOverflow, { flush: "post" });
+watch(() => props.orientation, updateOverflow, { flush: "post" });
 
 // Slide direction
 const slideDirection = computed(() => {
@@ -151,44 +212,49 @@ const messages = useMessages();
     ]"
   >
     <!-- Tab bar -->
-    <div
-      class="cui-tabs__bar"
-      role="tablist"
-      :aria-orientation="orientation"
-      @keydown="onKeydown"
-    >
-      <button
-        v-for="tab in tabs"
-        :key="tab.value"
-        :data-cui-tab-value="tab.value"
-        class="cui-tabs__tab"
-        :class="{
-          'cui-tabs__tab--active': activeTab === tab.value,
-          'cui-tabs__tab--disabled': tab.disabled,
-        }"
-        :style="{
-          '--_tab-color': `var(--cui-${color})`,
-          '--_tab-hover': `var(--cui-${color}-hover)`,
-          '--_tab-bg': `var(--cui-${color}-bg)`,
-        }"
-        role="tab"
-        :aria-selected="activeTab === tab.value"
-        :aria-disabled="tab.disabled || undefined"
-        :tabindex="activeTab === tab.value ? 0 : -1"
-        @click="activate(tab.value)"
+    <div class="cui-tabs__bar-outer">
+      <div
+        ref="barRef"
+        class="cui-tabs__bar"
+        role="tablist"
+        :aria-orientation="orientation"
+        :data-overflow="overflowEdges"
+        @keydown="onKeydown"
+        @scroll="updateOverflow"
       >
-        <span class="cui-tabs__tab-content">{{ tab.label }}</span>
         <button
-          v-if="tab.closeable"
-          type="button"
-          class="cui-tabs__tab-close"
-          :aria-label="messages.tabs.closeTab"
-          tabindex="-1"
-          @click.stop="close(tab.value)"
+          v-for="tab in tabs"
+          :key="tab.value"
+          :data-cui-tab-value="tab.value"
+          class="cui-tabs__tab"
+          :class="{
+            'cui-tabs__tab--active': activeTab === tab.value,
+            'cui-tabs__tab--disabled': tab.disabled,
+          }"
+          :style="{
+            '--_tab-color': `var(--cui-${color})`,
+            '--_tab-hover': `var(--cui-${color}-hover)`,
+            '--_tab-bg': `var(--cui-${color}-bg)`,
+          }"
+          role="tab"
+          :aria-selected="activeTab === tab.value"
+          :aria-disabled="tab.disabled || undefined"
+          :tabindex="activeTab === tab.value ? 0 : -1"
+          @click="activate(tab.value)"
         >
-          <CuiIcon name="x" size="0.75rem" />
+          <span class="cui-tabs__tab-content">{{ tab.label }}</span>
+          <button
+            v-if="tab.closeable"
+            type="button"
+            class="cui-tabs__tab-close"
+            :aria-label="messages.tabs.closeTab"
+            tabindex="-1"
+            @click.stop="close(tab.value)"
+          >
+            <CuiIcon name="x" size="0.75rem" />
+          </button>
         </button>
-      </button>
+      </div>
     </div>
 
     <!-- Panels -->
@@ -201,6 +267,8 @@ const messages = useMessages();
 <style scoped>
 .cui-tabs {
   display: flex;
+  /* allow shrinking inside a flex parent instead of forcing overflow */
+  min-width: 0;
 }
 
 .cui-tabs--horizontal {
@@ -212,48 +280,125 @@ const messages = useMessages();
   gap: calc(1rem * var(--cui-density-scale, 1));
 }
 
-/* --- Tab bar --- */
-.cui-tabs__bar {
+/* --- Tab bar ---
+   Two elements on purpose: the outer holds the static chrome (underline border,
+   segmented track) while the inner is the scroll viewport, so the chrome neither
+   scrolls away nor gets caught by the inner's edge-fade mask. */
+.cui-tabs__bar-outer {
   display: flex;
   flex-shrink: 0;
+  min-width: 0;
+}
+
+.cui-tabs__bar {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  scroll-behavior: smooth;
+  /* Native bar is hidden — the edge fade is the overflow affordance. Consumers
+     wanting a visible one can add `.cui-scrollbar` and override these. */
+  scrollbar-width: none;
+  -webkit-mask-image: var(--_tab-fade, none);
+  mask-image: var(--_tab-fade, none);
+}
+
+.cui-tabs__bar::-webkit-scrollbar {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cui-tabs__bar {
+    scroll-behavior: auto;
+  }
 }
 
 .cui-tabs--horizontal .cui-tabs__bar {
   flex-direction: row;
   gap: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.cui-tabs--vertical .cui-tabs__bar-outer {
+  min-width: 10rem;
+  min-height: 0;
 }
 
 .cui-tabs--vertical .cui-tabs__bar {
   flex-direction: column;
   gap: 0;
-  min-width: 10rem;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+/* Edge fade — set by the `data-overflow` state, which tracks scroll position */
+.cui-tabs--horizontal .cui-tabs__bar[data-overflow="end"] {
+  --_tab-fade: linear-gradient(to right, #000 calc(100% - 1.5rem), transparent 100%);
+}
+
+.cui-tabs--horizontal .cui-tabs__bar[data-overflow="start"] {
+  --_tab-fade: linear-gradient(to left, #000 calc(100% - 1.5rem), transparent 100%);
+}
+
+.cui-tabs--horizontal .cui-tabs__bar[data-overflow="both"] {
+  --_tab-fade: linear-gradient(
+    to right,
+    transparent 0,
+    #000 1.5rem,
+    #000 calc(100% - 1.5rem),
+    transparent 100%
+  );
+}
+
+.cui-tabs--vertical .cui-tabs__bar[data-overflow="end"] {
+  --_tab-fade: linear-gradient(to bottom, #000 calc(100% - 1.5rem), transparent 100%);
+}
+
+.cui-tabs--vertical .cui-tabs__bar[data-overflow="start"] {
+  --_tab-fade: linear-gradient(to top, #000 calc(100% - 1.5rem), transparent 100%);
+}
+
+.cui-tabs--vertical .cui-tabs__bar[data-overflow="both"] {
+  --_tab-fade: linear-gradient(
+    to bottom,
+    transparent 0,
+    #000 1.5rem,
+    #000 calc(100% - 1.5rem),
+    transparent 100%
+  );
 }
 
 /* Underline variant */
-.cui-tabs--underline.cui-tabs--horizontal .cui-tabs__bar {
+.cui-tabs--underline.cui-tabs--horizontal .cui-tabs__bar-outer {
   border-bottom: 1px solid var(--cui-border);
 }
 
-.cui-tabs--underline.cui-tabs--vertical .cui-tabs__bar {
+.cui-tabs--underline.cui-tabs--vertical .cui-tabs__bar-outer {
   border-right: 1px solid var(--cui-border);
-  padding-right: 0;
 }
 
-/* Segmented variant */
-.cui-tabs--segmented .cui-tabs__bar {
+/* Segmented variant — track lives on the outer; the 0.25rem inset is split
+   across both so the active pill's drop shadow isn't clipped by the scroller. */
+.cui-tabs--segmented .cui-tabs__bar-outer {
   background: var(--color-surface-100);
   border-radius: var(--cui-button-radius, 0.375rem);
-  padding: calc(0.25rem * var(--cui-density-scale, 1));
-  gap: calc(0.25rem * var(--cui-density-scale, 1));
+  padding: calc(0.125rem * var(--cui-density-scale, 1));
 }
 
-:where(.dark, .dark *) .cui-tabs--segmented .cui-tabs__bar {
+:where(.dark, .dark *) .cui-tabs--segmented .cui-tabs__bar-outer {
   background: var(--color-surface-800);
+}
+
+.cui-tabs--segmented .cui-tabs__bar {
+  padding: calc(0.125rem * var(--cui-density-scale, 1));
+  gap: calc(0.25rem * var(--cui-density-scale, 1));
 }
 
 /* --- Tab button --- */
 .cui-tabs__tab {
   display: flex;
+  flex-shrink: 0;
   align-items: center;
   gap: calc(0.375rem * var(--cui-density-scale, 1));
   padding: calc(0.625rem * var(--cui-density-scale, 1)) calc(1rem * var(--cui-density-scale, 1));

--- a/packages/clean-ui/src/components/__tests__/CuiTabs.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiTabs.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { mount } from "@vue/test-utils";
 import { defineComponent, ref } from "vue";
 import CuiTabs from "../CuiTabs.vue";
@@ -90,5 +90,94 @@ describe("CuiTabs + CuiTab", () => {
 
     expect(tabs[0].attributes("aria-selected")).toBe("true");
     expect(tabs[1].attributes("aria-selected")).toBe("false");
+  });
+});
+
+describe("CuiTabs overflow", () => {
+  /** jsdom reports every element as 0x0; fake a scrollable bar. */
+  function stubMetrics(
+    el: HTMLElement,
+    { client, scroll, pos }: { client: number; scroll: number; pos: number },
+  ) {
+    Object.defineProperty(el, "clientWidth", { value: client, configurable: true });
+    Object.defineProperty(el, "scrollWidth", { value: scroll, configurable: true });
+    Object.defineProperty(el, "scrollLeft", { value: pos, configurable: true, writable: true });
+  }
+
+  it("renders the tablist inside a separate scroll viewport", async () => {
+    const wrapper = mount(makeHost());
+    await wrapper.vm.$nextTick();
+    const bar = wrapper.get('[role="tablist"]');
+    expect(bar.classes()).toContain("cui-tabs__bar");
+    expect(bar.element.parentElement?.className).toContain("cui-tabs__bar-outer");
+  });
+
+  it("reports no overflow when the tabs fit", async () => {
+    const wrapper = mount(makeHost());
+    await wrapper.vm.$nextTick();
+    expect(wrapper.get('[role="tablist"]').attributes("data-overflow")).toBe("none");
+  });
+
+  it("marks the clipped edges as content scrolls", async () => {
+    const wrapper = mount(makeHost());
+    await wrapper.vm.$nextTick();
+    const bar = wrapper.get('[role="tablist"]');
+    const el = bar.element as HTMLElement;
+
+    stubMetrics(el, { client: 200, scroll: 500, pos: 0 });
+    await bar.trigger("scroll");
+    expect(bar.attributes("data-overflow")).toBe("end");
+
+    stubMetrics(el, { client: 200, scroll: 500, pos: 150 });
+    await bar.trigger("scroll");
+    expect(bar.attributes("data-overflow")).toBe("both");
+
+    stubMetrics(el, { client: 200, scroll: 500, pos: 300 });
+    await bar.trigger("scroll");
+    expect(bar.attributes("data-overflow")).toBe("start");
+  });
+
+  it("scrolls the newly active tab into view on a v-model change", async () => {
+    const wrapper = mount(makeHost(), { attachTo: document.body });
+    await wrapper.vm.$nextTick();
+
+    const target = wrapper.findAll('[role="tab"]')[1].element as HTMLElement;
+    const spy = vi.fn();
+    target.scrollIntoView = spy;
+
+    (wrapper.vm as unknown as { active: string }).active = "two";
+    await wrapper.vm.$nextTick();
+
+    expect(spy).toHaveBeenCalledWith({ inline: "nearest", block: "nearest" });
+    wrapper.unmount();
+  });
+
+  it("scopes the keyboard-nav tab lookup to its own tablist", async () => {
+    // Two tab sets sharing tab values: arrow-key nav must focus the local tab
+    const host = defineComponent({
+      components: { CuiTabs, CuiTab },
+      template: `
+        <div>
+          <CuiTabs data-set="a">
+            <CuiTab value="one" label="One">A one</CuiTab>
+            <CuiTab value="two" label="Two">A two</CuiTab>
+          </CuiTabs>
+          <CuiTabs data-set="b">
+            <CuiTab value="one" label="One">B one</CuiTab>
+            <CuiTab value="two" label="Two">B two</CuiTab>
+          </CuiTabs>
+        </div>
+      `,
+    });
+    const wrapper = mount(host, { attachTo: document.body });
+    await wrapper.vm.$nextTick();
+
+    const second = wrapper.findAll(".cui-tabs")[1];
+    await second.get('[role="tablist"]').trigger("keydown", { key: "ArrowRight" });
+    await wrapper.vm.$nextTick();
+
+    const focused = document.activeElement as HTMLElement;
+    expect(second.element.contains(focused)).toBe(true);
+    wrapper.unmount();
   });
 });


### PR DESCRIPTION
## Problem

`CuiTabs`' bar was a plain flex row with no overflow handling, so tabs that didn't fit painted outside the bar's box. Inside a `CuiModal` / `CuiSlideover` (whose panels are `overflow: hidden`) the trailing tabs were clipped away and unreachable by any input.

One correction to the report: `.cui-tabs__bar` already had `flex-shrink: 0` — that's for the bar as a column flex item and wasn't the cause. The missing piece was `overflow-x`.

## Approach

- **Two-element bar.** `.cui-tabs__bar-outer` holds the static chrome (underline border, segmented track); `.cui-tabs__bar` is the scroll viewport. This keeps the chrome from scrolling away and from being caught by the edge-fade mask. The segmented `0.25rem` inset is split 2px/2px across the two so the active pill's drop shadow isn't clipped by the scroller — total geometry is unchanged.
- **Overflow.** `overflow-x: auto` horizontally, `overflow-y: auto` vertically, `flex-shrink: 0` on tabs, `min-width: 0` on the root so the component can shrink inside a flex parent.
- **Affordance.** Native scrollbar hidden; a `data-overflow="none|start|end|both"` attribute drives a `mask-image` fade on whichever edge has content out of view. State comes from a scroll handler + `ResizeObserver`, with watchers on tab count and orientation. A raw `scrollbar-width: thin` was rejected here: it sits on the underline border and, on macOS, is an overlay bar that's invisible until you already know to scroll.
- **Scroll into view.** Active tab scrolls into view on `v-model` change and at mount. Keyboard nav already got this free via `focus()`. `scroll-behavior: smooth`, off under `prefers-reduced-motion`.
- **Drive-by fix.** `onKeydown` used a global `document.querySelector` for the tab to focus, which hit the wrong element when two `CuiTabs` on a page shared tab values. Now scoped to the component's own tablist.

No API or prop changes; layout is identical when the tabs already fit.

## Docs

Two demos on the Tabs page (`/components/tabs`): a slider-driven container (240–720px, defaulting to the 343px phone width from the report) with an underline/segmented toggle and an "activate last tab" button, plus the original repro inside a `CuiSlideover`.

## Testing

- `CuiTabs.test.ts`: 5 new tests (11 total, passing) — scroll-viewport structure, `data-overflow` transitions across scroll positions, `scrollIntoView` on v-model change, and the scoped-lookup regression.
- `pnpm build` and the docs build (`vue-tsc --noEmit`) pass clean.
- Note: `useDensity.test.ts` and `smoke.test.ts` fail on `develop` already (`localStorage.getItem is not a function`), unrelated to this change.

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)