### PR TITLE
fix(table): contain horizontal overflow by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `CuiTable` header backgrounds now reference the `--cui-table-head-bg` token instead of raw surface scale steps, so overriding it works on sticky tables and `CuiDataGrid` (#64)
+- `CuiTable` now always renders its scroll wrapper (`<div class="cui-table-wrapper">`) around the `<table>`, not only when `minWidth`/`maxHeight` is passed. The wrapper stays inert (`overflow: visible`) while the table fits and only becomes a scroll container when the table actually overflows, so page-scrolled `stickyHeader` tables are unaffected. **DOM change:** a CSS selector matching `.cui-table` as a direct child of a specific element needs updating (#58)
+- New `table.scrollRegionLabel` message key (default `"Scrollable table"`) — the accessible name for a table's scroll region (#58)
 
 ### Fixed
 - `CuiTableCell` inside a `CuiTableHead` now renders `<th scope="col">` instead of `<td>`. Vue casts an absent `Boolean` prop to `false`, so the explicit-override branch always won and the section context was never consulted — which also meant `sticky-header` was a silent no-op, since its CSS matches `thead th`. **DOM change:** consumer CSS targeting `thead td` needs updating (#64)
 - `CuiTabs` tab bar now scrolls when the tabs overflow their container, with an edge fade marking the clipped side — trailing tabs were previously clipped and unreachable inside `CuiModal` / `CuiSlideover` (#57)
 - `CuiTabs` keyboard navigation no longer focuses a tab in a different `CuiTabs` instance when two tab sets on a page share tab values (#57)
+- Wide `CuiTable`s no longer overflow their ancestor into page-level horizontal scroll with no affordance — horizontal scroll containment and the scroll-shadow fade are now the default instead of requiring `minWidth`/`maxHeight` (#58)
+- A scrolling `CuiTable` (including `CuiDataGrid`'s) is now keyboard-reachable — `role="region"`, `tabindex="0"`, and a focus ring, per WCAG 2.1.1 (#58)
 
 ## [1.0.1] - 2026-06-29
 

--- a/apps/docs/src/pages/LocalizationPage.vue
+++ b/apps/docs/src/pages/LocalizationPage.vue
@@ -132,7 +132,7 @@ const es = {
           <code class="cui-code">confirmDialog</code>, <code class="cui-code">pagination</code>,
           <code class="cui-code">breadcrumb</code>, <code class="cui-code">stepper</code>,
           <code class="cui-code">skeleton</code>, <code class="cui-code">tabs</code>,
-          <code class="cui-code">dataGrid</code>. See the
+          <code class="cui-code">table</code>, <code class="cui-code">dataGrid</code>. See the
           <code class="cui-code">CuiMessages</code> type for the full shape — your editor will
           autocomplete every key.
         </p>

--- a/apps/docs/src/pages/TablePage.vue
+++ b/apps/docs/src/pages/TablePage.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
+import { ref } from "vue";
 import {
   CuiBadge,
   CuiCard,
   CuiCardBody,
+  CuiSlider,
   CuiStack,
   CuiTable,
   CuiTableHead,
@@ -23,6 +25,8 @@ const employees = [
 ];
 
 const stickyStyle = { position: 'sticky' as const, top: '0', zIndex: 10, background: 'var(--color-surface-50)' };
+
+const overflowWidth = ref(343);
 
 const stickyData = [
   ...employees,
@@ -463,6 +467,67 @@ const stickyData = [
               </CuiTable>
             </CuiCardBody>
           </CuiCard>
+        </Example>
+
+        <!-- Horizontal overflow -->
+        <Example title="Horizontal overflow (automatic)" :code="`<!-- No props needed — a table too wide for its container
+     scrolls inside it instead of overflowing the page -->
+<CuiTable hoverable>
+  <CuiTableHead>…</CuiTableHead>
+  <CuiTableBody>…</CuiTableBody>
+</CuiTable>`">
+          <CuiStack spacing="4">
+            <p class="text-sm text-surface-500">
+              A table wider than its container scrolls horizontally within it, with a fade on the
+              clipped edge. The wrapper only becomes a scroll container when it has to — while the
+              table fits it stays inert, so a page-scrolled
+              <code class="cui-code">sticky-header</code> keeps working. Drag the width to see it
+              engage.
+            </p>
+
+            <CuiSlider
+              v-model="overflowWidth"
+              label="Container width"
+              :min="240"
+              :max="900"
+              :step="1"
+              show-value
+              :format-value="(v: number) => `${v}px`"
+            />
+
+            <div :style="{ width: `${overflowWidth}px`, maxWidth: '100%' }">
+              <CuiCard variant="outline">
+                <CuiCardBody no-padding>
+                  <CuiTable hoverable>
+                    <CuiTableHead>
+                      <CuiTableRow>
+                        <CuiTableCell nowrap>Name</CuiTableCell>
+                        <CuiTableCell nowrap>Role</CuiTableCell>
+                        <CuiTableCell nowrap>Email</CuiTableCell>
+                        <CuiTableCell nowrap>Status</CuiTableCell>
+                        <CuiTableCell nowrap align="right">Salary</CuiTableCell>
+                      </CuiTableRow>
+                    </CuiTableHead>
+                    <CuiTableBody>
+                      <CuiTableRow v-for="emp in employees" :key="emp.name">
+                        <CuiTableCell nowrap>{{ emp.name }}</CuiTableCell>
+                        <CuiTableCell nowrap>{{ emp.role }}</CuiTableCell>
+                        <CuiTableCell nowrap>{{ emp.email }}</CuiTableCell>
+                        <CuiTableCell nowrap>{{ emp.status }}</CuiTableCell>
+                        <CuiTableCell nowrap align="right">{{ emp.salary }}</CuiTableCell>
+                      </CuiTableRow>
+                    </CuiTableBody>
+                  </CuiTable>
+                </CuiCardBody>
+              </CuiCard>
+            </div>
+
+            <p class="text-sm text-surface-500">
+              Once it scrolls, the wrapper becomes a keyboard-reachable
+              <code class="cui-code">role="region"</code> with a focus ring — tab to it and use the
+              arrow keys.
+            </p>
+          </CuiStack>
         </Example>
 
       </CuiStack>

--- a/packages/clean-ui/src/components/CuiDataGridTable.vue
+++ b/packages/clean-ui/src/components/CuiDataGridTable.vue
@@ -230,11 +230,12 @@ const auxHeaderCellStyle = computed(() =>
 // ---------------------------------------------------------------------------
 // Virtualization
 // ---------------------------------------------------------------------------
-// The scrollable element is CuiTable's internal wrapper div, which it exposes
-// via defineExpose({ scrollWrapper }) and only exists when maxHeight is set.
-// We capture it through CuiTable's :ref and hand it to the virtualizer so it
-// can listen for scroll events. When virtualization is off (or maxHeight is
-// unset) we leave the container null and the virtualizer stays dormant.
+// The scrollable element is CuiTable's internal wrapper div, which it always
+// renders and exposes via defineExpose({ scrollWrapper }). We capture it through
+// CuiTable's :ref and hand it to the virtualizer so it can listen for scroll
+// events. Vertical scrolling still requires maxHeight, so when virtualization is
+// off (or maxHeight is unset) we leave the container null and the virtualizer
+// stays dormant.
 const scrollContainerRef = ref<HTMLElement | null>(null);
 
 function setScrollContainer(wrapper: HTMLElement | null) {

--- a/packages/clean-ui/src/components/CuiTable.vue
+++ b/packages/clean-ui/src/components/CuiTable.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
-import { computed, provide, ref } from "vue";
+import { computed, provide, ref, watch, onMounted, onBeforeUnmount } from "vue";
 import { TableContextKey } from "./table-context";
 import type { SizeableProps, HideableProps } from "../types/common";
 import { clampSize } from "../utils/sizing";
 import { useScrollShadows, scrollShadowBottomStyle, scrollShadowRightStyle } from "../composables/useScrollShadows";
+import { useMessages } from "../composables/useMessages";
+import { warnOnce } from "../utils/devWarn";
 
 export interface CuiTableProps extends HideableProps, SizeableProps {
   /** Alternating row backgrounds */
@@ -58,54 +60,103 @@ const tableClasses = computed(() => [
   },
 ]);
 
-const wrapperStyle = computed(() => {
-  if (!props.maxHeight && !props.minWidth) return undefined;
-  const s: Record<string, string> = { overflow: "auto", position: "relative" };
-  if (props.maxHeight) s.maxHeight = props.maxHeight;
-  return s;
-});
-
 const tableStyle = computed(() => ({
   borderCollapse: "separate" as const,
   borderSpacing: "0",
   minWidth: props.minWidth || undefined,
 }));
 
-const { canScrollRight, canScrollDown, onScroll, onMount: onWrapperRef } = useScrollShadows();
+const { canScrollRight, canScrollDown, onScroll: onShadowScroll, update } = useScrollShadows();
 
 const scrollWrapper = ref<HTMLElement | null>(null);
+const tableEl = ref<HTMLElement | null>(null);
 
-function setWrapperRef(el: any) {
-  scrollWrapper.value = el as HTMLElement | null;
-  onWrapperRef(el as HTMLElement | null);
+// --- Overflow containment ---
+// The wrapper is always rendered, but it only becomes a scroll container when it
+// has to. `overflow-x: auto` forces overflow-y to compute to `auto` as well, which
+// would re-parent a sticky <thead> to this wrapper's scrollport — as tall as the
+// content, so the header would never actually stick during page scroll. Staying
+// `visible` while the table fits keeps that case behaving natively.
+const isOverflowingX = ref(false);
+
+const scrollable = computed(() => !!props.maxHeight || isOverflowingX.value);
+
+const wrapperStyle = computed(() => {
+  const s: Record<string, string> = { position: "relative" };
+  if (props.maxHeight) {
+    s.overflow = "auto";
+    s.maxHeight = props.maxHeight;
+  } else if (isOverflowingX.value) {
+    s.overflowX = "auto";
+  }
+  return s;
+});
+
+function measure() {
+  const wrap = scrollWrapper.value;
+  const table = tableEl.value;
+  if (!wrap || !table) return;
+
+  // Measured off the table, not the wrapper: an `overflow: visible` wrapper
+  // doesn't reliably report overflowing content in its own scrollWidth.
+  isOverflowingX.value = Math.max(table.scrollWidth, table.offsetWidth) - wrap.clientWidth > 1;
+  update(wrap);
+
+  if (isOverflowingX.value && props.stickyHeader && !props.maxHeight) {
+    warnOnce(
+      "[clean-ui] CuiTable: stickyHeader with a horizontally overflowing table needs " +
+        "maxHeight. The scroll container required to contain the overflow also becomes " +
+        "the sticky header's scrollport, so the header can't stick to the viewport.",
+    );
+  }
 }
 
-defineExpose({ scrollWrapper });
+let resizeObserver: ResizeObserver | undefined;
+
+onMounted(() => {
+  requestAnimationFrame(measure);
+  if (typeof ResizeObserver !== "undefined") {
+    resizeObserver = new ResizeObserver(measure);
+    // Both: the wrapper for viewport changes, the table for content changes
+    if (scrollWrapper.value) resizeObserver.observe(scrollWrapper.value);
+    if (tableEl.value) resizeObserver.observe(tableEl.value);
+  }
+});
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect();
+  resizeObserver = undefined;
+});
+
+watch(() => [props.minWidth, props.maxHeight, props.fixedLayout], measure, { flush: "post" });
+
+const messages = useMessages();
+
+defineExpose({ scrollWrapper, measure });
 
 </script>
 
 <template>
-  <!-- Scroll wrapper when maxHeight or minWidth is set -->
-  <div v-if="maxHeight || minWidth" v-show="!hidden" style="position: relative;">
+  <!-- The wrapper always renders; it only becomes a scroll container when the
+       table overflows (or maxHeight is set). See `wrapperStyle` above. -->
+  <div v-show="!hidden" style="position: relative;">
     <div
-      :ref="setWrapperRef"
+      ref="scrollWrapper"
       class="cui-table-wrapper"
       :style="wrapperStyle"
-      @scroll="onScroll"
+      :role="scrollable ? 'region' : undefined"
+      :tabindex="scrollable ? 0 : undefined"
+      :aria-label="scrollable ? messages.table.scrollRegionLabel : undefined"
+      @scroll="onShadowScroll"
     >
-      <table :class="tableClasses" :style="tableStyle" :aria-rowcount="ariaRowcount">
+      <table ref="tableEl" :class="tableClasses" :style="tableStyle" :aria-rowcount="ariaRowcount">
         <slot />
       </table>
     </div>
 
-    <div v-if="canScrollRight" :style="scrollShadowRightStyle" />
-    <div v-if="canScrollDown" :style="scrollShadowBottomStyle" />
+    <div v-if="scrollable && canScrollRight" :style="scrollShadowRightStyle" />
+    <div v-if="scrollable && canScrollDown" :style="scrollShadowBottomStyle" />
   </div>
-
-  <!-- Bare table -->
-  <table v-else v-show="!hidden" :class="tableClasses" style="border-collapse: separate; border-spacing: 0;" :aria-rowcount="ariaRowcount">
-    <slot />
-  </table>
 </template>
 
 <style>
@@ -113,6 +164,13 @@ defineExpose({ scrollWrapper });
 
 .cui-table-wrapper {
   position: relative;
+}
+
+/* The wrapper is a tab stop only while it scrolls (WCAG 2.1.1 — scrollable
+   regions must be keyboard-reachable), so give it a visible focus ring. */
+.cui-table-wrapper:focus-visible {
+  outline: 2px solid var(--cui-primary-focus-ring);
+  outline-offset: 2px;
 }
 
 .cui-table {

--- a/packages/clean-ui/src/components/__tests__/CuiTable.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiTable.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { mount } from "@vue/test-utils";
 import { h } from "vue";
 import CuiTable from "../CuiTable.vue";
@@ -145,5 +145,73 @@ describe("CuiTable + sub-components", () => {
     // the table lives inside the scroll wrapper
     expect(scroller.find("table.cui-table").exists()).toBe(true);
     expect((scroller.element as HTMLElement).style.maxHeight).toBe("200px");
+  });
+});
+
+describe("CuiTable overflow containment", () => {
+  /** jsdom lays nothing out; fake a table wider than its wrapper. */
+  function forceOverflow(wrapper: ReturnType<typeof mountTable>, overflowing: boolean) {
+    const scroller = wrapper.find(".cui-table-wrapper").element as HTMLElement;
+    const table = wrapper.find("table.cui-table").element as HTMLElement;
+    Object.defineProperty(scroller, "clientWidth", { value: 300, configurable: true });
+    Object.defineProperty(table, "offsetWidth", {
+      value: overflowing ? 900 : 300,
+      configurable: true,
+    });
+    Object.defineProperty(table, "scrollWidth", {
+      value: overflowing ? 900 : 300,
+      configurable: true,
+    });
+    return (wrapper.vm as unknown as { measure: () => void }).measure();
+  }
+
+  it("always renders the wrapper, even with no sizing props", () => {
+    const wrapper = mountTable();
+    const scroller = wrapper.find(".cui-table-wrapper");
+    expect(scroller.exists()).toBe(true);
+    expect(scroller.find("table.cui-table").exists()).toBe(true);
+  });
+
+  it("leaves the wrapper inert while the table fits", async () => {
+    const wrapper = mountTable();
+    forceOverflow(wrapper, false);
+    await wrapper.vm.$nextTick();
+
+    const scroller = wrapper.find(".cui-table-wrapper");
+    const style = (scroller.element as HTMLElement).style;
+    // no overflow at all — a scroll container here would break a sticky thead
+    expect(style.overflow).toBe("");
+    expect(style.overflowX).toBe("");
+    expect(scroller.attributes("tabindex")).toBeUndefined();
+    expect(scroller.attributes("role")).toBeUndefined();
+  });
+
+  it("becomes a keyboard-reachable scroll region once the table overflows", async () => {
+    const wrapper = mountTable();
+    forceOverflow(wrapper, true);
+    await wrapper.vm.$nextTick();
+
+    const scroller = wrapper.find(".cui-table-wrapper");
+    expect((scroller.element as HTMLElement).style.overflowX).toBe("auto");
+    expect(scroller.attributes("tabindex")).toBe("0");
+    expect(scroller.attributes("role")).toBe("region");
+    expect(scroller.attributes("aria-label")).toBe("Scrollable table");
+  });
+
+  it("treats a maxHeight table as a scroll region without measuring", () => {
+    const wrapper = mountTable({ maxHeight: "200px" });
+    const scroller = wrapper.find(".cui-table-wrapper");
+    expect((scroller.element as HTMLElement).style.overflow).toBe("auto");
+    expect(scroller.attributes("tabindex")).toBe("0");
+    expect(scroller.attributes("role")).toBe("region");
+  });
+
+  it("warns when stickyHeader is used on an overflowing table without maxHeight", () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const wrapper = mountTable({ stickyHeader: true });
+    forceOverflow(wrapper, true);
+
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("stickyHeader"));
+    spy.mockRestore();
   });
 });

--- a/packages/clean-ui/src/messages.ts
+++ b/packages/clean-ui/src/messages.ts
@@ -50,6 +50,10 @@ export interface CuiMessages {
   stepper: { label: string };
   skeleton: { label: string };
   tabs: { closeTab: string };
+  table: {
+    /** Accessible name for the scroll region a table gets when it overflows. */
+    scrollRegionLabel: string;
+  };
   dataGrid: {
     noResultsTitle: string;
     noResultsDescription: string;
@@ -98,6 +102,7 @@ export const defaultMessages: CuiMessages = {
   stepper: { label: "Progress" },
   skeleton: { label: "Loading" },
   tabs: { closeTab: "Close tab" },
+  table: { scrollRegionLabel: "Scrollable table" },
   dataGrid: {
     noResultsTitle: "No results found",
     noResultsDescription: "Try adjusting your search or filters.",

--- a/packages/clean-ui/src/utils/devWarn.ts
+++ b/packages/clean-ui/src/utils/devWarn.ts
@@ -9,7 +9,7 @@ const ROLE_LIST =
 // across bundlers in a published ESM library is brittle, and these only ever fire
 // on genuine misuse, never on valid usage.)
 const warned = new Set<string>();
-function warnOnce(message: string): void {
+export function warnOnce(message: string): void {
   if (warned.has(message)) return;
   warned.add(message);
   console.warn(message);


### PR DESCRIPTION
## Problem

`CuiTable` only rendered its scroll wrapper when a caller passed `minWidth` or `maxHeight`. Without either, a wide table overflowed its ancestor into page-level horizontal scroll with no affordance that content was cut off — callers had to remember to opt in.

## Approach

The wrapper is now always rendered, but it only becomes a scroll container when it has to.

`overflow-x: auto` forces `overflow-y` to compute to `auto` as well, which would re-parent a sticky `<thead>` to this wrapper's scrollport — as tall as its content, so the header would never stick during page scroll. Staying `visible` while the table fits keeps that case behaving exactly as before:

| state | wrapper |
| --- | --- |
| table fits | `position: relative` only — inert, page-scroll sticky headers unaffected |
| table overflows | `overflow-x: auto` + right-edge scroll fade |
| `maxHeight` set | `overflow: auto` + `max-height` (unchanged) |

A `ResizeObserver` on both the wrapper and the table drives the flip. Overflow is measured off the table (`offsetWidth`/`scrollWidth` vs the wrapper's `clientWidth`) because an `overflow: visible` wrapper doesn't reliably report overflowing content in its own `scrollWidth`. The one combination that can't work — `stickyHeader` + real horizontal overflow + no `maxHeight` — logs a one-time dev warning pointing at `maxHeight` (`warnOnce` is now exported from `devWarn.ts`).

## Accessibility

While it scrolls, the wrapper is a keyboard-reachable region: `role="region"`, `tabindex="0"`, and a focus ring, named by a new `table.scrollRegionLabel` message key (WCAG 2.1.1 — scrollable regions must be reachable by keyboard). This lands on `CuiDataGrid` too, which already always took the wrapper path and had the same gap.

**Deliberately skipped:** a left-edge fade for symmetry. `useScrollShadows` already tracks `canScrollLeft`, but in `CuiDataGrid` a left fade would sit on top of the pinned sticky columns and fade pinned content.

## Breaking-ish

Every `CuiTable` now has a wrapping `<div>`, so a consumer selector matching `.cui-table` as a direct child of a specific element needs updating. Called out in `CHANGELOG.md` under `Changed`; worth a minor bump as the issue suggests.

## Docs

A width-adjustable overflow demo on the Table page (`/components/table`), plus the new `table` namespace on the Localization page.

## Testing

- `CuiTable.test.ts`: 5 new tests — wrapper always present, inert while the table fits, becomes a scroll region on overflow, `maxHeight` path unchanged, dev warning fires. `CuiDataGrid.test.ts` still green.
- Full suite: 213 passed. `useDensity.test.ts` / `smoke.test.ts` fail on `develop` already (`localStorage.getItem is not a function`), unrelated.
- Library build and docs build (`vue-tsc --noEmit`) pass clean.

### Browser verification (post-rebase)

Rebased onto `develop` after #66 merged. That fix is what makes the central design claim here testable at all — sticky headers were a no-op before it, so "the inert wrapper preserves page-scroll sticky" could not be observed. Re-verified in headless Chrome over CDP:

| case | result |
| --- | --- |
| sticky header + `maxHeight` (docs demo) | `<th>` holds at offset `0` after a 163px scroll |
| **no `maxHeight`, table fits, page scroll** | wrapper computes `visible/visible`; page scrolled 500px, table top moved to `-400`, header stayed pinned at `0` |

The second row is the case the dynamic-overflow design exists to protect.

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)