### PR TITLE
fix(table): render head cells as <th>, restoring sticky headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `CuiTable` header backgrounds now reference the `--cui-table-head-bg` token instead of raw surface scale steps, so overriding it works on sticky tables and `CuiDataGrid` (#64)
+
 ### Fixed
+- `CuiTableCell` inside a `CuiTableHead` now renders `<th scope="col">` instead of `<td>`. Vue casts an absent `Boolean` prop to `false`, so the explicit-override branch always won and the section context was never consulted — which also meant `sticky-header` was a silent no-op, since its CSS matches `thead th`. **DOM change:** consumer CSS targeting `thead td` needs updating (#64)
 - `CuiTabs` tab bar now scrolls when the tabs overflow their container, with an edge fade marking the clipped side — trailing tabs were previously clipped and unreachable inside `CuiModal` / `CuiSlideover` (#57)
 - `CuiTabs` keyboard navigation no longer focuses a tab in a different `CuiTabs` instance when two tab sets on a page share tab values (#57)
 

--- a/packages/clean-ui/src/components/CuiDataGridTable.vue
+++ b/packages/clean-ui/src/components/CuiDataGridTable.vue
@@ -185,6 +185,10 @@ function stickyBodyColStyle(colKey: string): Record<string, string | number> | u
 // `top: 0` when stickyHeader is on; sticky columns additionally get `left`. A
 // cell that's both (the top-left corner) sits above the regular header row (10)
 // and the sticky body column (4) at z-index 11.
+//
+// These cells are <th>, so `.cui-table--sticky-header thead th` also applies:
+// it agrees on position/top, and deliberately leaves z-index and left alone so
+// the inline values here still win.
 function headerCellStyle(col: { key: string; sortable?: boolean; sticky?: boolean }) {
   const leftVal = stickyColumnOffsets.value.get(col.key);
   const stickyCol = !!leftVal;

--- a/packages/clean-ui/src/components/CuiTable.vue
+++ b/packages/clean-ui/src/components/CuiTable.vue
@@ -160,20 +160,17 @@ defineExpose({ scrollWrapper });
   text-transform: uppercase;
   letter-spacing: 0.03em;
   color: var(--cui-text-secondary);
-  background: var(--color-surface-50);
+  background: var(--cui-table-head-bg, var(--color-surface-50));
   border-bottom: 1px solid var(--cui-border);
   text-align: left;
 }
 
 :where(.dark, .dark *) .cui-table thead th {
-  background: var(--color-surface-800);
+  background: var(--cui-table-head-bg, var(--color-surface-800));
 }
 
-/* CuiDataGrid renders td-based header cells (CuiTableCell) inside <thead>, which
-   the th-only rule above can't match — so the header→body divider was missing on
-   the DataGrid. Give td headers the same divider. (Only the border: DataGrid pins
-   its header at the cell level via headerCellStyle, so we deliberately do NOT add
-   a sticky position rule for td here — that would re-create the nested-sticky bug.) */
+/* A cell can still opt out of header semantics with an explicit `header={false}`
+   inside a <thead>, so keep the divider on td head cells too. */
 .cui-table thead td {
   border-bottom: 1px solid var(--cui-border);
 }
@@ -223,11 +220,14 @@ defineExpose({ scrollWrapper });
      and a sticky column (the top-left "corner") needs to layer above its
      neighbours, which it does by setting a higher z-index inline. */
   z-index: 10;
-  background: var(--color-surface-50) !important;
+  /* Token, not a raw scale step: CuiDataGrid pins its own header cells inline
+     with the same token, and this !important would otherwise clobber a
+     consumer's --cui-table-head-bg override on every sticky grid. */
+  background: var(--cui-table-head-bg, var(--color-surface-50)) !important;
 }
 
 :where(.dark, .dark *) .cui-table--sticky-header thead th {
-  background: var(--color-surface-800) !important;
+  background: var(--cui-table-head-bg, var(--color-surface-800)) !important;
 }
 
 /* --- Selected row --- */

--- a/packages/clean-ui/src/components/CuiTableCell.vue
+++ b/packages/clean-ui/src/components/CuiTableCell.vue
@@ -21,6 +21,10 @@ export interface CuiTableCellProps extends HideableProps {
 }
 
 const props = withDefaults(defineProps<CuiTableCellProps>(), {
+  // Declaring a default — even `undefined` — opts this Boolean prop out of Vue's
+  // absent-prop casting, which would otherwise hand us `false` and make the
+  // "explicit override" branch below indistinguishable from "not passed".
+  header: undefined,
   align: "left",
   nowrap: false,
   hidden: false,

--- a/packages/clean-ui/src/components/CuiTableHead.vue
+++ b/packages/clean-ui/src/components/CuiTableHead.vue
@@ -12,11 +12,11 @@ withDefaults(defineProps<CuiTableHeadProps>(), {
 
 provide(TableSectionContextKey, { isHead: true });
 
-// Sticky header is pinned at the CELL level (each th/td gets position: sticky;
+// Sticky header is pinned at the CELL level (each cell gets position: sticky;
 // top: 0), NOT on the <thead>. A sticky <thead> + sticky cells is a nested
 // same-axis sticky, which detaches sticky-column header cells from the header's
 // vertical pinning. See `.cui-table--sticky-header thead th` and, for the data
-// grid (td-based headers), CuiDataGridTable's headerCellStyle.
+// grid, CuiDataGridTable's headerCellStyle.
 </script>
 
 <template>

--- a/packages/clean-ui/src/components/__tests__/CuiDataGrid.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiDataGrid.test.ts
@@ -15,10 +15,19 @@ const data: DataGridRow[] = [
 ];
 
 function headerCells(wrapper: ReturnType<typeof mount>) {
-  return wrapper.findAll("thead th, thead td");
+  return wrapper.findAll("thead th");
 }
 
 describe("CuiDataGrid sticky columns", () => {
+  it("renders header cells as <th scope=col>", () => {
+    const wrapper = mount(CuiDataGrid, {
+      props: { columns, data, maxHeight: "320px", hideToolbar: true },
+    });
+    expect(wrapper.findAll("thead td")).toHaveLength(0);
+    expect(headerCells(wrapper)[0].attributes("scope")).toBe("col");
+    wrapper.unmount();
+  });
+
   it("pins a sticky-column header cell on BOTH axes (top + left) so it stays put on vertical scroll", () => {
     const wrapper = mount(CuiDataGrid, {
       props: { columns, data, maxHeight: "320px", hideToolbar: true },

--- a/packages/clean-ui/src/components/__tests__/CuiTable.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiTable.test.ts
@@ -71,6 +71,47 @@ describe("CuiTable + sub-components", () => {
     expect(bodyCells[0].text()).toBe("Alice");
   });
 
+  it("infers <th scope=col> for cells in the head with no header prop", () => {
+    // The common case: callers don't pass `header`, so the cell has to derive it
+    // from the section context. A Boolean prop cast to `false` when absent would
+    // silently make these <td> and break the sticky-header rule.
+    const wrapper = mount(CuiTable, {
+      props: { stickyHeader: true },
+      slots: {
+        default: () => [
+          h(CuiTableHead, () => [
+            h(CuiTableRow, () => [h(CuiTableCell, () => "Name"), h(CuiTableCell, () => "Score")]),
+          ]),
+          h(CuiTableBody, () => [
+            h(CuiTableRow, () => [h(CuiTableCell, () => "Alice"), h(CuiTableCell, () => "10")]),
+          ]),
+        ],
+      },
+    });
+
+    const headCells = wrapper.findAll("thead th");
+    expect(headCells).toHaveLength(2);
+    expect(headCells[0].attributes("scope")).toBe("col");
+    expect(wrapper.findAll("thead td")).toHaveLength(0);
+    // body cells are unaffected
+    expect(wrapper.findAll("tbody td")).toHaveLength(2);
+  });
+
+  it("honors an explicit header={false} inside the head", () => {
+    const wrapper = mount(CuiTable, {
+      slots: {
+        default: () => [
+          h(CuiTableHead, () => [
+            h(CuiTableRow, () => [h(CuiTableCell, { header: false }, () => "Plain")]),
+          ]),
+        ],
+      },
+    });
+
+    expect(wrapper.find("thead td").exists()).toBe(true);
+    expect(wrapper.find("thead th").exists()).toBe(false);
+  });
+
   it("applies the align style on a cell", () => {
     const wrapper = mountTable();
     const scoreHeader = wrapper.findAll("thead th")[1];


### PR DESCRIPTION
## Problem

`CuiTableCell` is meant to infer `<th scope="col">` from the injected `TableSectionContext` when it sits inside a `CuiTableHead`. It never did — every head cell in the library rendered `<td>`.

Vue casts an absent `Boolean` prop to `false`, not `undefined`, so the explicit-override branch always won:

```ts
header?: boolean;   // no declared default → absent becomes `false`

const isHeader = computed(() => {
  if (props.header !== undefined) return props.header;  // always true → always false
  return section?.isHead ?? false;                      // never reached
});
```

Two consequences: header cells lost `<th>` + `scope="col"` semantics, and `sticky-header` became a **silent no-op** — its rule is `.cui-table--sticky-header thead th`, which matched nothing. The docs "Sticky Header" example has not been sticking.

## Fix

Declare `header: undefined` in `withDefaults` to opt the prop out of Boolean casting, so "not passed" stays distinguishable and the section context is consulted.

Second change: the sticky-header background now reads `--cui-table-head-bg` instead of a raw surface step. `CuiDataGrid` pins its own header cells inline with that token, and now that those cells are `<th>` the `!important` rule applies to them — which would otherwise clobber a consumer's override on every sticky grid. This also makes plain `CuiTable` honor a token that `.cui-typography th` and the DataGrid already used.

## Verification

None of this is observable in jsdom, so I drove headless Chrome over CDP against the docs site. On the DataGrid with both sticky header and sticky columns:

| check | result |
| --- | --- |
| header pinned through a 150px vertical scroll | `top: 0` held (corner + plain cells) |
| corner cell through a 300px horizontal scroll | `left: 0`, `z-index: 11` held |
| body sticky column | pin held |
| non-sticky header cell | moved exactly `-300px` with the scroll |
| head cell tags across the page | all `TH`, all `scope="col"` |
| header background | correct in light and dark; a `--cui-table-head-bg` override survives on every cell |

Docs Table page: the sticky example now holds at offset `0` after scrolling, as `<th scope="col">` with `position: sticky`.

## Tests

- `CuiTable.test.ts`: head cells with no `header` prop are `<th scope="col">` with zero `thead td`; an explicit `header={false}` inside a head still renders `<td>`.
- `CuiDataGrid.test.ts`: asserts `<th scope="col">`; its `headerCells()` helper no longer accepts `thead th, thead td` — that tolerance was hiding this bug.
- Full suite: 208 passed. `useDensity.test.ts` / `smoke.test.ts` fail on `develop` already (`localStorage.getItem is not a function`), unrelated.
- Library and docs builds pass clean.

## Notes

- **DOM change:** consumer CSS targeting `thead td` needs updating. The `.cui-table thead td` divider rule stays (it still covers an explicit `header={false}`), but its DataGrid rationale from #43/#55 no longer applies and the comment is updated accordingly.
- Branched from `develop`, so it will conflict lightly with #65 (both touch the `CHANGELOG.md` Unreleased section and the `CuiTable.vue` style block). Whichever merges second needs a trivial rebase.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)