### PR TITLE
fix(storage): guard localStorage access behind a shared helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,12 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 20 is the support floor; 24 catches breakage from newer runtime
+        # globals (e.g. Node >= 22's built-in localStorage shadowing jsdom's).
+        node-version: [20, 24]
     steps:
       - uses: actions/checkout@v4
 
@@ -19,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CuiTable` header backgrounds now reference the `--cui-table-head-bg` token instead of raw surface scale steps, so overriding it works on sticky tables and `CuiDataGrid` (#64)
 
 ### Fixed
+- Storage access no longer throws where `localStorage` exists but is unusable — sandboxed iframes without `allow-same-origin`, Safari private mode, blocked cookies, exceeded quota. `useDensity`, `useDataGridViews`' `localStorageViewAdapter`, and `CuiBanner` were unguarded; `useDensity` read at module scope, so a single throw took down every import of the library barrel. All storage now routes through one guarded helper (#67)
+- Test suite runs on modern Node again: Node ≥22 ships an inert global `localStorage` that shadows jsdom's, which broke the `useDensity` and smoke suites at collect time. CI now runs a Node 20 + 24 matrix so runtime-dependent breakage surfaces (#67)
 - `CuiTableCell` inside a `CuiTableHead` now renders `<th scope="col">` instead of `<td>`. Vue casts an absent `Boolean` prop to `false`, so the explicit-override branch always won and the section context was never consulted — which also meant `sticky-header` was a silent no-op, since its CSS matches `thead th`. **DOM change:** consumer CSS targeting `thead td` needs updating (#64)
 - `CuiTabs` tab bar now scrolls when the tabs overflow their container, with an edge fade marking the clipped side — trailing tabs were previously clipped and unreachable inside `CuiModal` / `CuiSlideover` (#57)
 - `CuiTabs` keyboard navigation no longer focuses a tab in a different `CuiTabs` instance when two tab sets on a page share tab values (#57)

--- a/packages/clean-ui/src/components/CuiBanner.vue
+++ b/packages/clean-ui/src/components/CuiBanner.vue
@@ -5,6 +5,7 @@ import CuiIcon from "./CuiIcon.vue";
 import CuiButton from "./CuiButton.vue";
 import { COLOR_ICON_MAP } from "../utils/colorIconMap";
 import { resolveLiveRegion } from "../utils/liveRegion";
+import { safeGetItem, safeSetItem } from "../utils/storage";
 
 export type BannerPosition = "top" | "bottom";
 export type BannerVariant = "solid" | "subtle";
@@ -35,15 +36,15 @@ const emit = defineEmits<{
   dismiss: [];
 }>();
 
-// Check localStorage for previously dismissed banners
+// Check storage for previously dismissed banners
 const dismissed = ref(
-  props.storageKey ? localStorage.getItem(`cui-banner-${props.storageKey}`) === "1" : false,
+  props.storageKey ? safeGetItem(`cui-banner-${props.storageKey}`) === "1" : false,
 );
 
 function dismiss() {
   dismissed.value = true;
   if (props.storageKey) {
-    localStorage.setItem(`cui-banner-${props.storageKey}`, "1");
+    safeSetItem(`cui-banner-${props.storageKey}`, "1");
   }
   emit("dismiss");
 }

--- a/packages/clean-ui/src/composables/useDataGridViews.ts
+++ b/packages/clean-ui/src/composables/useDataGridViews.ts
@@ -1,5 +1,6 @@
 import { ref } from "vue";
 import type { DataGridSavedView, DataGridViewAdapter } from "../types/data-grid";
+import { safeGetItem, safeSetItem } from "../utils/storage";
 
 /** Built-in localStorage adapter */
 export function localStorageViewAdapter(prefix = "cui-datagrid"): DataGridViewAdapter {
@@ -9,10 +10,12 @@ export function localStorageViewAdapter(prefix = "cui-datagrid"): DataGridViewAd
 
   return {
     async load(gridId: string): Promise<DataGridSavedView[]> {
+      const raw = safeGetItem(storageKey(gridId));
+      if (!raw) return [];
       try {
-        const raw = localStorage.getItem(storageKey(gridId));
-        return raw ? JSON.parse(raw) : [];
+        return JSON.parse(raw);
       } catch {
+        // Corrupt payload — treat as no saved views
         return [];
       }
     },
@@ -25,13 +28,13 @@ export function localStorageViewAdapter(prefix = "cui-datagrid"): DataGridViewAd
       } else {
         views.push(view);
       }
-      localStorage.setItem(storageKey(gridId), JSON.stringify(views));
+      safeSetItem(storageKey(gridId), JSON.stringify(views));
     },
 
     async remove(gridId: string, viewId: string): Promise<void> {
       const views = await this.load(gridId);
       const filtered = views.filter((v) => v.id !== viewId);
-      localStorage.setItem(storageKey(gridId), JSON.stringify(filtered));
+      safeSetItem(storageKey(gridId), JSON.stringify(filtered));
     },
   };
 }

--- a/packages/clean-ui/src/composables/useDensity.ts
+++ b/packages/clean-ui/src/composables/useDensity.ts
@@ -1,4 +1,5 @@
 import { ref, watch } from "vue";
+import { safeGetItem, safeSetItem } from "../utils/storage";
 
 export type DensityId = "compact" | "default" | "comfortable";
 
@@ -24,8 +25,7 @@ const VALID_IDS = new Set<string>(DENSITY_PRESETS.map((p) => p.id));
 const activeDensity = ref<DensityId>(loadDensity());
 
 function loadDensity(): DensityId {
-  if (typeof window === "undefined") return DEFAULT;
-  const stored = localStorage.getItem(STORAGE_KEY);
+  const stored = safeGetItem(STORAGE_KEY);
   return stored && VALID_IDS.has(stored) ? (stored as DensityId) : DEFAULT;
 }
 
@@ -40,7 +40,7 @@ function applyDensity(id: DensityId) {
   // default == :root baseline, so no class is needed for it.
   if (id !== "default") root.classList.add(`${CLASS_PREFIX}${id}`);
 
-  localStorage.setItem(STORAGE_KEY, id);
+  safeSetItem(STORAGE_KEY, id);
 }
 
 // Apply on init + on change.

--- a/packages/clean-ui/src/composables/useTheme.ts
+++ b/packages/clean-ui/src/composables/useTheme.ts
@@ -1,4 +1,5 @@
 import { ref, watch } from "vue";
+import { safeGetItem, safeSetItem } from "../utils/storage";
 
 export interface ThemePreset {
   id: string;
@@ -20,15 +21,8 @@ export const THEME_PRESETS: ThemePreset[] = [
 const STORAGE_KEY = "cui-theme";
 const CLASS_PREFIX = "cui-theme-";
 
-const isBrowser = typeof window !== "undefined";
-
 function loadTheme(): string {
-  if (!isBrowser) return "mono";
-  try {
-    return localStorage.getItem(STORAGE_KEY) ?? "mono";
-  } catch {
-    return "mono";
-  }
+  return safeGetItem(STORAGE_KEY) ?? "mono";
 }
 
 // Shared reactive state
@@ -54,13 +48,7 @@ applyTheme(activeTheme.value);
 
 watch(activeTheme, (newTheme) => {
   applyTheme(newTheme);
-  if (isBrowser) {
-    try {
-      localStorage.setItem(STORAGE_KEY, newTheme);
-    } catch {
-      // localStorage unavailable (SSR, private browsing, etc.)
-    }
-  }
+  safeSetItem(STORAGE_KEY, newTheme);
 });
 
 /**

--- a/packages/clean-ui/src/test-setup.ts
+++ b/packages/clean-ui/src/test-setup.ts
@@ -16,6 +16,29 @@ if (!window.matchMedia) {
   }));
 }
 
+// Node >= 22 ships a global `localStorage` that is inert without
+// --localstorage-file (no getItem), and it shadows jsdom's Storage. Swap in a
+// working in-memory one so tests exercise real persistence rather than the
+// library's no-storage fallback path.
+if (typeof globalThis.localStorage?.getItem !== "function") {
+  const store = new Map<string, string>();
+  const memoryStorage: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key) => store.get(key) ?? null,
+    key: (index) => [...store.keys()][index] ?? null,
+    removeItem: (key) => void store.delete(key),
+    setItem: (key, value) => void store.set(key, String(value)),
+  };
+  Object.defineProperty(globalThis, "localStorage", {
+    value: memoryStorage,
+    configurable: true,
+    writable: true,
+  });
+}
+
 if (!("ResizeObserver" in globalThis)) {
   globalThis.ResizeObserver = class {
     observe() {}

--- a/packages/clean-ui/src/utils/__tests__/storage.test.ts
+++ b/packages/clean-ui/src/utils/__tests__/storage.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { safeGetItem, safeSetItem } from "../storage";
+
+const real = globalThis.localStorage;
+
+function stubStorage(value: unknown) {
+  Object.defineProperty(globalThis, "localStorage", {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+/** A storage whose every access throws, like a sandboxed iframe's. */
+function throwingStorage() {
+  return {
+    getItem() {
+      throw new DOMException("The operation is insecure.", "SecurityError");
+    },
+    setItem() {
+      throw new DOMException("The operation is insecure.", "SecurityError");
+    },
+  };
+}
+
+afterEach(() => stubStorage(real));
+
+describe("safe storage helpers", () => {
+  it("reads and writes through a working storage", () => {
+    expect(safeSetItem("cui-test", "value")).toBe(true);
+    expect(safeGetItem("cui-test")).toBe("value");
+  });
+
+  it("returns null / false when localStorage is missing", () => {
+    stubStorage(undefined);
+    expect(safeGetItem("cui-test")).toBeNull();
+    expect(safeSetItem("cui-test", "value")).toBe(false);
+  });
+
+  it("returns null / false for an inert storage with no getItem", () => {
+    // Node >= 22 without --localstorage-file exposes exactly this shape
+    stubStorage({});
+    expect(safeGetItem("cui-test")).toBeNull();
+    expect(safeSetItem("cui-test", "value")).toBe(false);
+  });
+
+  it("swallows a throwing storage instead of propagating", () => {
+    stubStorage(throwingStorage());
+    expect(() => safeGetItem("cui-test")).not.toThrow();
+    expect(safeGetItem("cui-test")).toBeNull();
+    expect(safeSetItem("cui-test", "value")).toBe(false);
+  });
+
+  it("reports a failed write when setItem throws (quota, private mode)", () => {
+    stubStorage({
+      getItem: () => null,
+      setItem: () => {
+        throw new DOMException("QuotaExceededError", "QuotaExceededError");
+      },
+    });
+    expect(safeSetItem("cui-test", "value")).toBe(false);
+  });
+});
+
+describe("module-scope storage access", () => {
+  it("imports useDensity without throwing when storage is inert", async () => {
+    stubStorage({});
+    // Force re-execution so the module-scope `loadDensity()` runs under the
+    // inert stub. That call is the regression: an unguarded read there took
+    // down every import of the library barrel, not just useDensity.
+    vi.resetModules();
+    const mod = await import("../../composables/useDensity");
+    expect(mod.useDensity).toBeTypeOf("function");
+    expect(mod.useDensity().density.value).toBe("default");
+  });
+});

--- a/packages/clean-ui/src/utils/storage.ts
+++ b/packages/clean-ui/src/utils/storage.ts
@@ -1,0 +1,47 @@
+/**
+ * Guarded Web Storage access.
+ *
+ * `localStorage` being *defined* doesn't mean it's usable: a sandboxed iframe
+ * without `allow-same-origin` throws on property access, Safari private mode and
+ * cookie-blocking settings can throw on read/write, and Node >= 22 exposes an
+ * inert global (no `getItem`) that jsdom-based test runners inherit. A
+ * `typeof window !== "undefined"` guard catches none of those.
+ *
+ * Route every read/write through here so a hostile storage environment
+ * degrades to "no persistence" instead of throwing — which matters most at
+ * module scope, where one throw takes the whole library barrel down.
+ */
+
+function getStorage(): Storage | null {
+  try {
+    // Property access itself can throw (sandboxed iframe)
+    if (typeof localStorage === "undefined" || localStorage === null) return null;
+    // Present but inert (Node's built-in Web Storage without --localstorage-file)
+    if (typeof localStorage.getItem !== "function") return null;
+    return localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/** Read a key, or `null` if storage is unavailable or the read throws. */
+export function safeGetItem(key: string): string | null {
+  try {
+    return getStorage()?.getItem(key) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Write a key. Returns whether it stuck — callers may ignore it. */
+export function safeSetItem(key: string, value: string): boolean {
+  try {
+    const storage = getStorage();
+    if (!storage) return false;
+    storage.setItem(key, value);
+    return true;
+  } catch {
+    // Quota exceeded, private mode, blocked storage
+    return false;
+  }
+}


### PR DESCRIPTION
## Problem

`localStorage` being *defined* doesn't mean it's usable:

- a sandboxed iframe without `allow-same-origin` throws on property access
- Safari private mode and cookie-blocking settings can throw on read/write
- exceeded quota throws on write
- Node ≥22 exposes an inert global (no `getItem`) that jsdom-based test runners inherit

A `typeof window !== "undefined"` guard — what `useDensity` had — catches none of them.

`useTheme` already wrapped its access in `try/catch`. `useDensity`, `useDataGridViews`' `localStorageViewAdapter`, and `CuiBanner` did not. `useDensity` is the dangerous one because it reads at **module scope**:

```ts
const activeDensity = ref<DensityId>(loadDensity());
```

so one throw takes down every import of the library barrel — which is exactly how this surfaced, as the `useDensity` and `smoke` suites failing to *collect* on Node 25 with `localStorage.getItem is not a function`.

## Fix

New `utils/storage.ts` — `safeGetItem` / `safeSetItem` — that feature-checks (`typeof localStorage.getItem === "function"`) inside a `try/catch`, so a hostile storage environment degrades to "no persistence" instead of throwing. All four call sites route through it, including `useTheme`, whose bespoke `try/catch` and now-unused `isBrowser` flag fold into the shared helper. `safeSetItem` returns whether the write stuck, for callers that care.

The SSR theme-init script (`ssr-theme-init.ts`) was already guarded — unchanged.

## Test environment and CI

- `test-setup.ts` installs an in-memory `Storage` when the ambient one lacks `getItem`, alongside the existing `matchMedia` / `ResizeObserver` stubs. Tests exercise real persistence rather than silently taking the no-storage path.
- CI gains a `[20, 24]` Node matrix. 20 is the support floor; 24 catches this class of runtime-global breakage, which a pinned 20 hid completely — CI was green this whole time.

## Testing

New `utils/__tests__/storage.test.ts` covers: working storage round-trips, missing storage, an inert `{}` storage (the exact Node ≥22 shape), a storage that throws `SecurityError` on every access, a `setItem` that throws `QuotaExceededError`, and — the regression itself — re-importing `useDensity` under inert storage without throwing.

Verified on both runtime shapes:

| Node | ambient `localStorage` | before | after |
| --- | --- | --- | --- |
| 25.2.1 | inert global | 2 files fail at collect, 213 tests run | **35/35 files, 371 passed** |
| 21.7.3 (CI 20's shape) | none — jsdom's Storage | green | **35/35 files, 371 passed** |

Library and docs builds pass clean.

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)