### PR TITLE
feat(tabs): add a #label slot for custom tab-button content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `CuiTab` accepts a `#label` slot for custom tab-button content — badges, icons, status dots. The `label` prop stays required and renders whenever no slot is given (#45)
+
 ### Changed
 - `CuiTable` header backgrounds now reference the `--cui-table-head-bg` token instead of raw surface scale steps, so overriding it works on sticky tables and `CuiDataGrid` (#64)
 - `CuiTable` now always renders its scroll wrapper (`<div class="cui-table-wrapper">`) around the `<table>`, not only when `minWidth`/`maxHeight` is passed. The wrapper stays inert (`overflow: visible`) while the table fits and only becomes a scroll container when the table actually overflows, so page-scrolled `stickyHeader` tables are unaffected. **DOM change:** a CSS selector matching `.cui-table` as a direct child of a specific element needs updating (#58)
 - New `table.scrollRegionLabel` message key (default `"Scrollable table"`) — the accessible name for a table's scroll region (#58)
 
 ### Fixed
+- A `CuiTab` no longer jumps to the end of the tab bar when one of its props changes — re-registration now updates in place instead of removing and re-appending (#45)
 - Storage access no longer throws where `localStorage` exists but is unusable — sandboxed iframes without `allow-same-origin`, Safari private mode, blocked cookies, exceeded quota. `useDensity`, `useDataGridViews`' `localStorageViewAdapter`, and `CuiBanner` were unguarded; `useDensity` read at module scope, so a single throw took down every import of the library barrel. All storage now routes through one guarded helper (#67)
 - Test suite runs on modern Node again: Node ≥22 ships an inert global `localStorage` that shadows jsdom's, which broke the `useDensity` and smoke suites at collect time. CI now runs a Node 20 + 24 matrix so runtime-dependent breakage surfaces (#67)
 - `CuiTableCell` inside a `CuiTableHead` now renders `<th scope="col">` instead of `<td>`. Vue casts an absent `Boolean` prop to `false`, so the explicit-override branch always won and the section context was never consulted — which also meant `sticky-header` was a silent no-op, since its CSS matches `thead th`. **DOM change:** consumer CSS targeting `thead td` needs updating (#64)

--- a/apps/docs/src/pages/TabsPage.vue
+++ b/apps/docs/src/pages/TabsPage.vue
@@ -2,6 +2,7 @@
 import { ref } from "vue";
 import {
   CuiAlert,
+  CuiBadge,
   CuiButton,
   CuiFlex,
   CuiFormField,
@@ -35,6 +36,9 @@ const overflowTabs = [
   { value: "billing", label: "Billing & Invoices" },
   { value: "advanced", label: "Advanced" },
 ];
+const customContent = ref("clients");
+const pendingClients = ref(3);
+
 const overflow = ref("general");
 const overflowWidth = ref(343);
 const overflowVariant = ref<"underline" | "segmented">("underline");
@@ -84,10 +88,18 @@ function resetTabs() {
       <PropTable
         :props="[
           { name: 'value', type: 'string', default: '—', description: 'Unique tab identifier (required)' },
-          { name: 'label', type: 'string', default: '—', description: 'Tab label text (required)' },
+          { name: 'label', type: 'string', default: '—', description: 'Tab label text (required); rendered in the tab button unless a #label slot is given' },
           { name: 'disabled', type: 'boolean', default: 'false', description: 'Disable this tab' },
           { name: 'closeable', type: 'boolean', default: 'false', description: 'Show close button' },
           { name: 'hidden', type: 'boolean', default: 'false', description: 'Hide the component (v-show)' },
+        ]"
+      />
+
+      <h3 class="mt-6 mb-2 text-lg font-semibold">CuiTab Slots</h3>
+      <PropTable
+        :props="[
+          { name: 'default', type: 'slot', default: '—', description: 'Panel content shown when the tab is active' },
+          { name: 'label', type: 'slot', default: '—', description: 'Custom tab-button content (badge, icon, status dot). Replaces the label prop in the button' },
         ]"
       />
     </div>
@@ -231,6 +243,54 @@ function resetTabs() {
               <p>Notifications content here.</p>
             </CuiTab>
           </CuiTabs>
+        </Example>
+
+        <!-- Custom tab content -->
+        <Example title="Custom Tab Content (#label slot)" :code="`<CuiTab value=&quot;clients&quot; label=&quot;Clients&quot;>
+  <template #label>
+    Clients <CuiBadge color=&quot;warning&quot; size=&quot;sm&quot;>{{ pending }}</CuiBadge>
+  </template>
+  <!-- panel content -->
+  <ClientList />
+</CuiTab>`">
+          <CuiStack spacing="3">
+            <p class="text-sm text-surface-500">
+              A <code class="cui-code">#label</code> slot on <code class="cui-code">CuiTab</code>
+              renders inside the tab button, for counts, icons, or status dots. The
+              <code class="cui-code">label</code> prop stays required and is used whenever no slot
+              is given — as on the last tab below.
+            </p>
+
+            <CuiTabs v-model="customContent">
+              <CuiTab value="clients" label="Clients">
+                <template #label>
+                  Clients
+                  <CuiBadge color="warning" size="sm">{{ pendingClients }}</CuiBadge>
+                </template>
+                <CuiFlex gap="2" align="center">
+                  <CuiButton size="sm" @click="pendingClients++">Add a pending client</CuiButton>
+                  <span class="text-sm text-surface-500">The badge updates in place.</span>
+                </CuiFlex>
+              </CuiTab>
+              <CuiTab value="reports" label="Reports">
+                <template #label>
+                  <CuiIcon name="chart-bar" size="1rem" />
+                  Reports
+                </template>
+                <p>An icon alongside the tab text.</p>
+              </CuiTab>
+              <CuiTab value="archive" label="Archive">
+                <p>No slot here — the label prop is rendered as plain text.</p>
+              </CuiTab>
+            </CuiTabs>
+
+            <p class="text-sm text-surface-500">
+              Keep the tab's text inside the slot: the button's accessible name comes from what it
+              renders, so <code class="cui-code">Clients 3</code> is announced in full. A slot with
+              no text at all (an icon on its own) would leave the tab unnamed — include
+              visually-hidden text in that case.
+            </p>
+          </CuiStack>
         </Example>
 
         <!-- Closeable -->

--- a/packages/clean-ui/src/components/CuiTab.vue
+++ b/packages/clean-ui/src/components/CuiTab.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { inject, onMounted, onUnmounted, computed, watch } from "vue";
+import { inject, onMounted, onUnmounted, computed, watch, useSlots } from "vue";
 import { TabsContextKey } from "./tabs-context";
 import type { HideableProps, DisableableProps } from "../types/common";
 
@@ -26,27 +26,33 @@ if (!ctx) {
 
 const isActive = computed(() => ctx.activeTab.value === props.value);
 
-// Register/unregister with parent
-onMounted(() => {
-  ctx.register({
+const slots = useSlots();
+
+function definition() {
+  return {
     value: props.value,
     label: props.label,
     disabled: props.disabled,
     closeable: props.closeable,
-  });
+    // Call through `slots` rather than capturing the slot function, so the
+    // parent's render always invokes the current one — a badge count in the
+    // slot updates without re-registering the tab.
+    labelSlot: slots.label ? () => slots.label?.() : undefined,
+  };
+}
+
+// Register with parent
+onMounted(() => {
+  ctx.register(definition());
 });
 
-// Update registration when props change
+// Re-register when what the bar renders changes. `register` updates in place,
+// so this can't reorder the tab. Slot *presence* is watched too: a tab that
+// gains a #label slot later still needs the parent to pick it up.
 watch(
-  () => ({ label: props.label, disabled: props.disabled, closeable: props.closeable }),
+  () => [props.label, props.disabled, props.closeable, !!slots.label],
   () => {
-    ctx.unregister(props.value);
-    ctx.register({
-      value: props.value,
-      label: props.label,
-      disabled: props.disabled,
-      closeable: props.closeable,
-    });
+    ctx.register(definition());
   },
 );
 

--- a/packages/clean-ui/src/components/CuiTabs.vue
+++ b/packages/clean-ui/src/components/CuiTabs.vue
@@ -56,7 +56,12 @@ watch(
 );
 
 function register(tab: TabDefinition) {
-  if (!tabs.value.find((t) => t.value === tab.value)) {
+  const idx = tabs.value.findIndex((t) => t.value === tab.value);
+  if (idx >= 0) {
+    // Update in place — re-pushing would jump the tab to the end of the bar
+    // whenever one of its props changed.
+    tabs.value[idx] = tab;
+  } else {
     tabs.value.push(tab);
   }
   // Auto-activate first tab
@@ -242,7 +247,10 @@ const messages = useMessages();
           :tabindex="activeTab === tab.value ? 0 : -1"
           @click="activate(tab.value)"
         >
-          <span class="cui-tabs__tab-content">{{ tab.label }}</span>
+          <span class="cui-tabs__tab-content">
+            <component :is="tab.labelSlot" v-if="tab.labelSlot" />
+            <template v-else>{{ tab.label }}</template>
+          </span>
           <button
             v-if="tab.closeable"
             type="button"

--- a/packages/clean-ui/src/components/__tests__/CuiTabs.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiTabs.test.ts
@@ -93,6 +93,83 @@ describe("CuiTabs + CuiTab", () => {
   });
 });
 
+describe("CuiTab #label slot", () => {
+  it("renders slot content inside the tab button instead of the label text", async () => {
+    const wrapper = mount(
+      defineComponent({
+        components: { CuiTabs, CuiTab },
+        setup: () => ({ count: ref(3) }),
+        template: `
+          <CuiTabs>
+            <CuiTab value="clients" label="Clients">
+              <template #label>Clients <span class="badge">{{ count }}</span></template>
+              Panel
+            </CuiTab>
+            <CuiTab value="plain" label="Plain">Panel two</CuiTab>
+          </CuiTabs>
+        `,
+      }),
+    );
+    await wrapper.vm.$nextTick();
+
+    const tabs = wrapper.findAll('[role="tab"]');
+    expect(tabs[0].find(".badge").exists()).toBe(true);
+    expect(tabs[0].text()).toBe("Clients 3");
+    // a tab without the slot still renders its label prop
+    expect(tabs[1].text()).toBe("Plain");
+    expect(tabs[1].find(".badge").exists()).toBe(false);
+  });
+
+  it("re-renders slot content when its reactive source changes", async () => {
+    const host = defineComponent({
+      components: { CuiTabs, CuiTab },
+      setup: () => ({ count: ref(3) }),
+      template: `
+        <CuiTabs>
+          <CuiTab value="clients" label="Clients">
+            <template #label>Clients <span class="badge">{{ count }}</span></template>
+            Panel
+          </CuiTab>
+        </CuiTabs>
+      `,
+    });
+    const wrapper = mount(host);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(".badge").text()).toBe("3");
+
+    (wrapper.vm as unknown as { count: number }).count = 7;
+    await wrapper.vm.$nextTick();
+    // the slot is invoked by CuiTabs' render, so the count must still track
+    expect(wrapper.find(".badge").text()).toBe("7");
+  });
+
+  it("keeps tab order when a tab's label prop changes", async () => {
+    const host = defineComponent({
+      components: { CuiTabs, CuiTab },
+      setup: () => ({ first: ref("One") }),
+      template: `
+        <CuiTabs>
+          <CuiTab value="one" :label="first">Panel one</CuiTab>
+          <CuiTab value="two" label="Two">Panel two</CuiTab>
+          <CuiTab value="three" label="Three">Panel three</CuiTab>
+        </CuiTabs>
+      `,
+    });
+    const wrapper = mount(host);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.findAll('[role="tab"]').map((t) => t.text())).toEqual(["One", "Two", "Three"]);
+
+    // Re-registering used to push the tab to the end of the bar
+    (wrapper.vm as unknown as { first: string }).first = "Renamed";
+    await wrapper.vm.$nextTick();
+    expect(wrapper.findAll('[role="tab"]').map((t) => t.text())).toEqual([
+      "Renamed",
+      "Two",
+      "Three",
+    ]);
+  });
+});
+
 describe("CuiTabs overflow", () => {
   /** jsdom reports every element as 0x0; fake a scrollable bar. */
   function stubMetrics(

--- a/packages/clean-ui/src/components/tabs-context.ts
+++ b/packages/clean-ui/src/components/tabs-context.ts
@@ -1,4 +1,4 @@
-import type { InjectionKey, Ref } from "vue";
+import type { InjectionKey, Ref, VNodeChild } from "vue";
 import type { CuiColor } from "../types/common";
 
 export type TabVariant = "underline" | "segmented";
@@ -10,6 +10,12 @@ export interface TabDefinition {
   label: string;
   disabled?: boolean;
   closeable?: boolean;
+  /**
+   * CuiTab's `#label` slot, forwarded so CuiTabs can render it inside the tab
+   * button (the button lives in the bar, which the parent owns). Absent when the
+   * tab has no `#label` slot, in which case the parent renders `label` as text.
+   */
+  labelSlot?: () => VNodeChild;
 }
 
 export interface TabsContext {


### PR DESCRIPTION
## What

`CuiTab` accepts a `#label` slot rendered inside the tab button — Option B from the issue, as discussed there with @Om-Beast.

```vue
<CuiTab value="clients" label="Clients">
  <template #label>
    Clients <CuiBadge color="warning" size="sm">{{ pending }}</CuiBadge>
  </template>
  <ClientList />
</CuiTab>
```

The `label` prop stays required and renders whenever no slot is given, so this is purely additive.

## How

`CuiTabs` renders the buttons from its registry while the slot lives on `CuiTab`, so the slot has to travel through registration. `CuiTab` forwards a thunk that calls **through** its `slots` object rather than capturing the slot function, so the parent always invokes the current one — a changing badge count re-renders without re-registering the tab. Slot *presence* is watched too, so a tab that gains a `#label` later is picked up.

**Drive-by fix:** registration is now an upsert. It previously removed and re-appended, so a tab jumped to the end of the bar whenever its `label`, `disabled`, or `closeable` prop changed. This feature would have made that much easier to hit, since re-registration is now also triggered by slot presence changing. Covered by a test.

## One deliberate deviation from the issue

The issue proposed keeping `label` as the `aria-label`. I did **not** do that, because it works against the feature: with content reading `Clients 3`, an `aria-label="Clients"` makes screen readers announce just "Clients" — hiding the unread count that is the whole point. The accessible name comes from the rendered content instead, so it's the full `"Clients 3"` (verified below).

The trade-off is a slot with no text at all (an icon on its own) would leave the tab unnamed. That's called out on the docs page, with the guidance to include visually-hidden text. Worth noting the library has no shared `.cui-sr-only` utility — four components inline the clip pattern privately. Happy to add one as a follow-up if you want that to be a public utility; it felt like an API decision to make on its own rather than as a side effect of this PR.

## Docs

New "Custom Tab Content (#label slot)" example on `/components/tabs` showing a live count badge, an icon tab, and a plain tab falling back to the prop — plus a `CuiTab Slots` table alongside the props table so the slot is discoverable without reading the example.

## Testing

Three new tests (14 in `CuiTabs.test.ts`): slot content renders in the button while a slot-less tab still shows its `label`; slot content re-renders when its reactive source changes; tab order survives a label change.

Verified in a real browser against the docs page:

| check | result |
| --- | --- |
| badge rendered inside the tab button | yes |
| badge reactivity | `3` → `4` on click |
| icon tab | renders its svg |
| tab with no slot | renders `Archive` from the prop |
| tab order after update | stable |
| accessible name | `"Clients 3"` — count included |

Full suite 379 passed / 18 skipped, 35/35 files. Library and docs builds clean.

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)