### PR TITLE
fix(overlay): hold the scroll lock on iOS Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `table.scrollRegionLabel` message key (default `"Scrollable table"`) — the accessible name for a table's scroll region (#58)
 
 ### Fixed
+- Overlay scroll lock now holds on iOS Safari — `overflow: hidden` on `<body>` doesn't stop touch scrolling there, so the page kept panning behind an open `CuiModal` / `CuiSlideover`. On iOS the body is pinned with `position: fixed` at its current offset and the scroll position is restored on close; other platforms keep the lighter `overflow` lock (#61)
+- Overlay scroll lock is reference-counted, so closing one of two stacked overlays no longer unlocks the page, and it restores the previous inline `<body>` styles instead of blanking them (#61)
+- Opening an overlay no longer shifts the page sideways where scrollbars take up space — the removed scrollbar's width is held as padding (#61)
 - A `CuiTab` no longer jumps to the end of the tab bar when one of its props changes — re-registration now updates in place instead of removing and re-appending (#45)
 - Storage access no longer throws where `localStorage` exists but is unusable — sandboxed iframes without `allow-same-origin`, Safari private mode, blocked cookies, exceeded quota. `useDensity`, `useDataGridViews`' `localStorageViewAdapter`, and `CuiBanner` were unguarded; `useDensity` read at module scope, so a single throw took down every import of the library barrel. All storage now routes through one guarded helper (#67)
 - Test suite runs on modern Node again: Node ≥22 ships an inert global `localStorage` that shadows jsdom's, which broke the `useDensity` and smoke suites at collect time. CI now runs a Node 20 + 24 matrix so runtime-dependent breakage surfaces (#67)

--- a/packages/clean-ui/src/components/__tests__/CuiModal.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiModal.test.ts
@@ -89,6 +89,45 @@ describe("CuiModal", () => {
     wrapper.unmount();
   });
 
+  it("locks body scroll while open and releases it on close", async () => {
+    const wrapper = mount(CuiModal, { props: { visible: true } });
+    await vi.runOnlyPendingTimersAsync();
+    expect(document.body.style.overflow).toBe("hidden");
+
+    await wrapper.setProps({ visible: false });
+    await vi.runOnlyPendingTimersAsync();
+    expect(document.body.style.overflow).toBe("");
+    wrapper.unmount();
+  });
+
+  it("releases the lock when unmounted while still open", async () => {
+    const wrapper = mount(CuiModal, { props: { visible: true } });
+    await vi.runOnlyPendingTimersAsync();
+    expect(document.body.style.overflow).toBe("hidden");
+
+    wrapper.unmount();
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("keeps the lock until the last of two stacked overlays closes", async () => {
+    const first = mount(CuiModal, { props: { visible: true } });
+    const second = mount(CuiModal, { props: { visible: true, allowNested: true } });
+    await vi.runOnlyPendingTimersAsync();
+    expect(document.body.style.overflow).toBe("hidden");
+
+    await second.setProps({ visible: false });
+    await vi.runOnlyPendingTimersAsync();
+    // the first modal is still open — the page must stay locked
+    expect(document.body.style.overflow).toBe("hidden");
+
+    await first.setProps({ visible: false });
+    await vi.runOnlyPendingTimersAsync();
+    expect(document.body.style.overflow).toBe("");
+
+    first.unmount();
+    second.unmount();
+  });
+
   it("persistent blocks Escape and backdrop close", async () => {
     const wrapper = mount(CuiModal, { props: { visible: true, persistent: true } });
     await vi.runOnlyPendingTimersAsync();

--- a/packages/clean-ui/src/composables/useOverlay.ts
+++ b/packages/clean-ui/src/composables/useOverlay.ts
@@ -1,4 +1,5 @@
 import { ref, watch, onMounted, onUnmounted, nextTick, type Ref, type ShallowRef } from "vue";
+import { lockBodyScroll, unlockBodyScroll } from "../utils/scrollLock";
 
 // Global set of active overlays shared across all instances
 const globalActiveOverlays = new Set<symbol>();
@@ -36,6 +37,24 @@ export function useOverlay(options: UseOverlayOptions) {
   const isAnimating = ref(false);
   const previousFocus = ref<HTMLElement | null>(null);
 
+  // The scroll lock is reference-counted globally, so this instance must
+  // release exactly what it took. close() can run without a preceding open
+  // (a `visible` flag set false while already closed) and unmount races the
+  // exit-animation timeout, so both paths go through this guard.
+  let holdsScrollLock = false;
+
+  function acquireScrollLock() {
+    if (holdsScrollLock) return;
+    holdsScrollLock = true;
+    lockBodyScroll();
+  }
+
+  function releaseScrollLock() {
+    if (!holdsScrollLock) return;
+    holdsScrollLock = false;
+    unlockBodyScroll();
+  }
+
   function openOverlay() {
     // One-at-a-time check
     if (!getAllowNested() && globalActiveOverlays.size > 0) {
@@ -46,8 +65,7 @@ export function useOverlay(options: UseOverlayOptions) {
     previousFocus.value = document.activeElement as HTMLElement;
     isVisible.value = true;
 
-    // Lock body scroll
-    document.body.style.overflow = "hidden";
+    acquireScrollLock();
 
     // nextTick alone schedules a microtask, which runs before the browser
     // paints — so the element mounts (off-screen transform) and flips to its
@@ -72,10 +90,7 @@ export function useOverlay(options: UseOverlayOptions) {
       onUpdateOpen(false);
       onClose();
 
-      // Restore body scroll if no other overlays
-      if (globalActiveOverlays.size === 0) {
-        document.body.style.overflow = "";
-      }
+      releaseScrollLock();
 
       // Return focus
       previousFocus.value?.focus();
@@ -134,9 +149,7 @@ export function useOverlay(options: UseOverlayOptions) {
 
   onUnmounted(() => {
     globalActiveOverlays.delete(overlayId);
-    if (globalActiveOverlays.size === 0) {
-      document.body.style.overflow = "";
-    }
+    releaseScrollLock();
   });
 
   return {

--- a/packages/clean-ui/src/test-setup.ts
+++ b/packages/clean-ui/src/test-setup.ts
@@ -39,6 +39,11 @@ if (typeof globalThis.localStorage?.getItem !== "function") {
   });
 }
 
+// jsdom ships window.scrollTo as a stub that logs "Not implemented: window.scrollTo"
+// on every call. The overlay scroll lock restores the scroll position through it,
+// so replace it with a silent no-op (still spy-able) instead of drowning the output.
+window.scrollTo = vi.fn() as unknown as typeof window.scrollTo;
+
 if (!("ResizeObserver" in globalThis)) {
   globalThis.ResizeObserver = class {
     observe() {}

--- a/packages/clean-ui/src/utils/__tests__/scrollLock.test.ts
+++ b/packages/clean-ui/src/utils/__tests__/scrollLock.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { lockBodyScroll, unlockBodyScroll, isBodyScrollLocked } from "../scrollLock";
+
+const IPHONE_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1";
+const IPAD_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15";
+const DESKTOP_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36";
+
+function setPlatform(userAgent: string, maxTouchPoints = 0) {
+  Object.defineProperty(navigator, "userAgent", { value: userAgent, configurable: true });
+  Object.defineProperty(navigator, "maxTouchPoints", { value: maxTouchPoints, configurable: true });
+}
+
+/** jsdom has no layout: fake a document that is scrolled with a classic scrollbar. */
+function fakeViewport({ scrollY = 0, scrollbar = 0 } = {}) {
+  Object.defineProperty(window, "scrollY", { value: scrollY, configurable: true, writable: true });
+  Object.defineProperty(window, "innerWidth", { value: 1000, configurable: true });
+  Object.defineProperty(document.documentElement, "clientWidth", {
+    value: 1000 - scrollbar,
+    configurable: true,
+  });
+}
+
+beforeEach(() => {
+  setPlatform(DESKTOP_UA);
+  fakeViewport();
+  document.body.style.cssText = "";
+});
+
+afterEach(() => {
+  // drain any lock left by a failing assertion
+  while (isBodyScrollLocked()) unlockBodyScroll();
+  document.body.style.cssText = "";
+  vi.restoreAllMocks();
+});
+
+describe("scroll lock — non-iOS", () => {
+  it("hides body overflow and restores it", () => {
+    lockBodyScroll();
+    expect(document.body.style.overflow).toBe("hidden");
+    unlockBodyScroll();
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("does not pin the body", () => {
+    lockBodyScroll();
+    expect(document.body.style.position).toBe("");
+    expect(document.body.style.top).toBe("");
+    unlockBodyScroll();
+  });
+
+  it("restores a pre-existing inline overflow rather than blanking it", () => {
+    document.body.style.overflow = "scroll";
+    lockBodyScroll();
+    expect(document.body.style.overflow).toBe("hidden");
+    unlockBodyScroll();
+    expect(document.body.style.overflow).toBe("scroll");
+  });
+
+  it("holds the scrollbar's width so the page doesn't shift", () => {
+    fakeViewport({ scrollbar: 15 });
+    lockBodyScroll();
+    expect(document.body.style.paddingRight).toBe("15px");
+    unlockBodyScroll();
+    expect(document.body.style.paddingRight).toBe("");
+  });
+
+  it("adds the scrollbar width on top of existing padding", () => {
+    fakeViewport({ scrollbar: 15 });
+    document.body.style.paddingRight = "8px";
+    lockBodyScroll();
+    expect(document.body.style.paddingRight).toBe("23px");
+    unlockBodyScroll();
+    expect(document.body.style.paddingRight).toBe("8px");
+  });
+
+  it("skips compensation when scrollbars are overlays", () => {
+    fakeViewport({ scrollbar: 0 });
+    lockBodyScroll();
+    expect(document.body.style.paddingRight).toBe("");
+    unlockBodyScroll();
+  });
+});
+
+describe("scroll lock — iOS", () => {
+  it("pins the body at its current offset on iPhone", () => {
+    setPlatform(IPHONE_UA);
+    fakeViewport({ scrollY: 420 });
+
+    lockBodyScroll();
+    expect(document.body.style.position).toBe("fixed");
+    expect(document.body.style.top).toBe("-420px");
+    expect(document.body.style.width).toBe("100%");
+    expect(document.body.style.overflow).toBe("hidden");
+  });
+
+  it("detects iPadOS, which reports a Mac UA with touch points", () => {
+    setPlatform(IPAD_UA, 5);
+    lockBodyScroll();
+    expect(document.body.style.position).toBe("fixed");
+    unlockBodyScroll();
+  });
+
+  it("treats a touchless Mac as desktop", () => {
+    setPlatform(IPAD_UA, 0);
+    lockBodyScroll();
+    expect(document.body.style.position).toBe("");
+    unlockBodyScroll();
+  });
+
+  it("restores the scroll position on unlock", () => {
+    setPlatform(IPHONE_UA);
+    fakeViewport({ scrollY: 420 });
+    const scrollTo = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+
+    lockBodyScroll();
+    unlockBodyScroll();
+
+    expect(scrollTo).toHaveBeenCalledWith(0, 420);
+    expect(document.body.style.position).toBe("");
+    expect(document.body.style.top).toBe("");
+  });
+
+  it("suppresses smooth scrolling for the restore jump", () => {
+    setPlatform(IPHONE_UA);
+    fakeViewport({ scrollY: 200 });
+    document.documentElement.style.scrollBehavior = "smooth";
+    let behaviorDuringRestore = "";
+    vi.spyOn(window, "scrollTo").mockImplementation(() => {
+      behaviorDuringRestore = document.documentElement.style.scrollBehavior;
+    });
+
+    lockBodyScroll();
+    unlockBodyScroll();
+
+    expect(behaviorDuringRestore).toBe("auto");
+    expect(document.documentElement.style.scrollBehavior).toBe("smooth");
+    document.documentElement.style.scrollBehavior = "";
+  });
+});
+
+describe("scroll lock — reference counting", () => {
+  it("stays locked until the last holder releases", () => {
+    lockBodyScroll();
+    lockBodyScroll();
+    unlockBodyScroll();
+    expect(document.body.style.overflow).toBe("hidden");
+    expect(isBodyScrollLocked()).toBe(true);
+
+    unlockBodyScroll();
+    expect(document.body.style.overflow).toBe("");
+    expect(isBodyScrollLocked()).toBe(false);
+  });
+
+  it("captures the scroll offset once, at the outermost lock", () => {
+    setPlatform(IPHONE_UA);
+    fakeViewport({ scrollY: 300 });
+    const scrollTo = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+
+    lockBodyScroll();
+    // A second overlay opening after the body is pinned would read scrollY 0
+    fakeViewport({ scrollY: 0 });
+    lockBodyScroll();
+    unlockBodyScroll();
+    unlockBodyScroll();
+
+    expect(scrollTo).toHaveBeenCalledWith(0, 300);
+  });
+
+  it("ignores an unbalanced unlock", () => {
+    unlockBodyScroll();
+    expect(isBodyScrollLocked()).toBe(false);
+
+    lockBodyScroll();
+    expect(document.body.style.overflow).toBe("hidden");
+    unlockBodyScroll();
+    expect(document.body.style.overflow).toBe("");
+  });
+});

--- a/packages/clean-ui/src/utils/scrollLock.ts
+++ b/packages/clean-ui/src/utils/scrollLock.ts
@@ -1,0 +1,127 @@
+/**
+ * Body scroll lock for overlays.
+ *
+ * `overflow: hidden` on <body> is enough on desktop and Android, but iOS Safari
+ * ignores it for touch scrolling — the page keeps panning behind an open modal.
+ * The reliable fix there is pinning the body with `position: fixed` at its
+ * current offset and restoring the scroll position on unlock, which we apply
+ * only on iOS: it's more invasive (the document is briefly out of flow, and the
+ * scroll position round-trips through JS), so platforms that honor
+ * `overflow: hidden` shouldn't pay for it.
+ *
+ * Locks are reference-counted. Stacked overlays each lock and unlock, and the
+ * document is only restored — and the scroll offset only captured — at the
+ * outermost boundary.
+ */
+
+interface SavedState {
+  overflow: string;
+  position: string;
+  top: string;
+  left: string;
+  right: string;
+  width: string;
+  paddingRight: string;
+  scrollY: number;
+  pinned: boolean;
+}
+
+let lockCount = 0;
+let saved: SavedState | null = null;
+
+/**
+ * iOS Safari, including iPadOS — which reports a Mac user agent and is only
+ * distinguishable by its touch points. Feature detection can't identify this
+ * behavior, so a narrow UA check is the pragmatic option.
+ */
+function isIOS(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const ua = navigator.userAgent;
+  if (/iP(hone|ad|od)/.test(ua)) return true;
+  return /Macintosh/.test(ua) && (navigator.maxTouchPoints ?? 0) > 1;
+}
+
+/** Width of the classic (space-consuming) scrollbar, 0 for overlay scrollbars. */
+function scrollbarWidth(): number {
+  return window.innerWidth - document.documentElement.clientWidth;
+}
+
+/** Lock body scrolling. Safe to call repeatedly — the lock is counted. */
+export function lockBodyScroll(): void {
+  if (typeof document === "undefined") return;
+
+  lockCount += 1;
+  if (lockCount > 1) return;
+
+  const body = document.body;
+  const pinned = isIOS();
+  const scrollY = window.scrollY;
+
+  saved = {
+    overflow: body.style.overflow,
+    position: body.style.position,
+    top: body.style.top,
+    left: body.style.left,
+    right: body.style.right,
+    width: body.style.width,
+    paddingRight: body.style.paddingRight,
+    scrollY,
+    pinned,
+  };
+
+  // Removing the scrollbar reflows the page; hold its width so content
+  // underneath doesn't jump sideways as the overlay opens.
+  const gap = scrollbarWidth();
+  if (gap > 0) {
+    const current = parseFloat(getComputedStyle(body).paddingRight) || 0;
+    body.style.paddingRight = `${current + gap}px`;
+  }
+
+  body.style.overflow = "hidden";
+
+  if (pinned) {
+    body.style.position = "fixed";
+    body.style.top = `-${scrollY}px`;
+    body.style.left = "0";
+    body.style.right = "0";
+    body.style.width = "100%";
+  }
+}
+
+/** Release one lock. The document is restored when the last one is released. */
+export function unlockBodyScroll(): void {
+  if (typeof document === "undefined") return;
+  if (lockCount === 0) return;
+
+  lockCount -= 1;
+  if (lockCount > 0 || !saved) return;
+
+  const body = document.body;
+  const { scrollY, pinned } = saved;
+
+  // Restore the exact previous inline values — blanking them would discard
+  // styles the consumer set themselves.
+  body.style.overflow = saved.overflow;
+  body.style.position = saved.position;
+  body.style.top = saved.top;
+  body.style.left = saved.left;
+  body.style.right = saved.right;
+  body.style.width = saved.width;
+  body.style.paddingRight = saved.paddingRight;
+  saved = null;
+
+  if (pinned) {
+    // Un-pinning drops the document back to offset 0, so put it back. Suppress
+    // `scroll-behavior: smooth` for the jump, or the restore animates.
+    const root = document.documentElement;
+    const previousBehavior = root.style.scrollBehavior;
+    root.style.scrollBehavior = "auto";
+    window.scrollTo(0, scrollY);
+    root.style.scrollBehavior = previousBehavior;
+  }
+}
+
+/** Whether a lock is currently held (exposed for tests). */
+export function isBodyScrollLocked(): boolean {
+  return lockCount > 0;
+}


### PR DESCRIPTION
## Problem

`document.body.style.overflow = "hidden"` (`useOverlay.ts:50`) doesn't stop touch scrolling in iOS Safari, so the page keeps panning behind an open `CuiModal` / `CuiSlideover` — sometimes scrolling the background out from under the overlay entirely.

## Approach

The lock moves into `utils/scrollLock.ts`. iOS additionally pins the body with `position: fixed` at its current offset and restores the scroll position on unlock; everywhere else keeps the plain `overflow` lock:

| platform | while open |
| --- | --- |
| desktop / Android | `overflow: hidden` |
| iOS (incl. iPadOS) | `overflow: hidden` + `position: fixed; top: -{scrollY}px`, scroll restored on close |

Applying the pin everywhere would be simpler, but it takes the document out of flow and round-trips the scroll offset through JS on engines that honor `overflow: hidden` and don't need it. iOS is identified by UA — including iPadOS, which reports a Mac UA and is only distinguishable by `maxTouchPoints` — because this behavior isn't feature-detectable.

## Two related defects fixed alongside

- **Reference counting.** Each overlay previously wrote the body style directly. The scroll offset is now captured only at the *outermost* lock: without that, a second overlay opening after the body was pinned would read `scrollY` 0 and restore the page to the top on close. `useOverlay` holds a per-instance guard, because close can run without a preceding open (a `visible` flag set false while already closed) and unmount races the exit-animation timeout. There's a test for two stacked overlays.
- **Style restoration.** Unlock restores the previous inline `<body>` values instead of blanking them, so a consumer's own `overflow` survives an overlay.

Also compensates for the scrollbar's width on lock, so opening an overlay no longer shifts the page sideways where scrollbars take up space.

## Testing

`utils/__tests__/scrollLock.test.ts` — 14 tests: the desktop path, iPhone and iPadOS detection, a touchless Mac treated as desktop, scroll restoration, `scroll-behavior: smooth` suppressed for the restore jump, scrollbar compensation (including on top of existing padding, and skipped for overlay scrollbars), reference counting, offset captured once, and an unbalanced unlock ignored. Plus three in `CuiModal.test.ts`: locked while open, released on unmount-while-open, and held until the last of two stacked overlays closes.

Verified in Chrome against the docs modal page, both branches:

| | desktop | iPhone UA |
| --- | --- | --- |
| while open | `overflow: hidden` only | `overflow: hidden` + `position: fixed`, `top: -300px` |
| `window.scrollY` while open | 300 | 0 (pinned) |
| after close | all inline styles cleared | all inline styles cleared |
| scroll after close | 300 | 300 |

**Honest limit:** that exercises the branch and the style/scroll round-trip in a real engine, not iOS Safari's actual touch behavior. Confirming the background no longer pans under a finger needs a real device — worth a spot-check on the downstream Pulse build before release.

Full suite 396 passed / 18 skipped, 36/36 files. Library and docs builds clean.

No API surface change, and the docs already describe overlays as having a scroll lock, so no docs update. One test-infra change: `test-setup.ts` stubs jsdom's unimplemented `window.scrollTo`, which the restore path otherwise makes log on every overlay test.

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)