### PR TITLE
feat(icons)!: resolve icons from a static set instead of the whole package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING (icons):** `CuiIcon` no longer resolves arbitrary names by importing all of `@phosphor-icons/vue`. It now renders from a static set — the 52 icons the library's own components draw — plus anything you register. An unregistered name renders a `?` glyph and logs how to fix it. Measured on an app rendering one icon: **1306 kB → 124 kB gzip, 1513 icons → 52** (#42)
+  - `registerIcons({ rocket: PhRocket })` adds your own statically-imported icons; each adds only itself to the bundle
+  - `<CuiIcon :icon="PhRocket" />` passes a component directly
+  - `import "@itguy614/clean-ui/icons/lazy"` restores the old any-name behavior in one line, at the old bundle cost — for apps whose icon names come from data
+- Icons in the static set now render synchronously, so they appear in SSR output and on first paint instead of after mount — the placeholder and the hydration workaround are gone for them (#42)
+
 ### Added
 - `CuiTab` accepts a `#label` slot for custom tab-button content — badges, icons, status dots. The `label` prop stays required and renders whenever no slot is given (#45)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 - pnpm monorepo: `packages/clean-ui` (library) + `apps/docs` (docs site)
 - Vue 3.5+ / TypeScript / Tailwind CSS v4 / Vite 6
 - Component prefix: `Cui` (CuiButton, CuiGrid, etc.)
-- Icons: Phosphor Icons via `@phosphor-icons/vue`, wrapped in `CuiIcon`
+- Icons: Phosphor Icons via `@phosphor-icons/vue`, wrapped in `CuiIcon`. **Every icon name the library renders must be statically imported into `src/icons/builtin.ts`** — `CuiIcon` has no dynamic import, so an unlisted name renders the `?` glyph. `src/icons/__tests__/builtin.test.ts` fails if you forget. Consumers add their own via `registerIcons()` or `<CuiIcon :icon="PhFoo" />`; the old any-name behavior is opt-in at `@itguy614/clean-ui/icons/lazy` (pulls in all ~1500 icons).
 - Positioning: `@floating-ui/vue` for tooltips; manual `computeDropdownPosition` for dropdowns/select
 
 ## Build & Dev
@@ -182,7 +182,7 @@ Compound sub-components for top-level composition, targeted slots inside them fo
 ## Adding a New Component — Checklist
 1. Read this file first. Follow established patterns.
 2. Create the `.vue` file in `src/components/`. If it needs shared context, create a `{name}-context.ts` file (NOT exports in the .vue file).
-3. Use `CuiIcon` for all icons (never inline SVGs).
+3. Use `CuiIcon` for all icons (never inline SVGs). Add any new icon name to `src/icons/builtin.ts`.
 4. Import sizes from `utils/sizing.ts`, not local maps.
 5. Use `var(--cui-surface-base)` for backgrounds, `var(--cui-border)` for borders.
 6. Use semantic color slots (`--cui-{color}-bg`, `--cui-{color}-border`, etc.) — never hardcoded oklch values that would break themes.

--- a/apps/docs/src/main.ts
+++ b/apps/docs/src/main.ts
@@ -1,5 +1,10 @@
 import { createApp } from "vue";
 import { createCleanUI } from "@itguy614/clean-ui";
+// This site is the unbounded case the opt-in exists for: it renders a gallery of
+// arbitrary Phosphor names to show what's available, so it accepts the full icon
+// package. An app should instead register the handful of icons it uses — see the
+// "Tree-shaking" section on the Icons page.
+import "@itguy614/clean-ui/icons/lazy";
 import router from "./router";
 import App from "./App.vue";
 import "./styles/main.css";

--- a/apps/docs/src/pages/IconPage.vue
+++ b/apps/docs/src/pages/IconPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { CuiCard, CuiCardBody, CuiIcon, CuiFlex, CuiStack } from "@itguy614/clean-ui";
+import { CuiAlert, CuiCard, CuiCardBody, CuiIcon, CuiFlex, CuiStack } from "@itguy614/clean-ui";
 import PropTable from "../components/PropTable.vue";
 import Example from "../components/Example.vue";
 
@@ -36,7 +36,8 @@ const commonIcons = [
       <h2 class="mb-4 text-2xl font-semibold">Props</h2>
       <PropTable
         :props="[
-          { name: 'name', type: 'string', default: '-', description: 'Phosphor icon name in kebab-case (e.g. check, warning-circle)' },
+          { name: 'name', type: 'string', default: '-', description: 'Phosphor icon name in kebab-case (e.g. check, warning-circle). Resolved from the built-in set plus anything you registered' },
+          { name: 'icon', type: 'Component', default: '-', description: 'A Phosphor component passed directly, e.g. :icon=&quot;PhRocket&quot;. Takes precedence over name' },
           { name: 'weight', type: 'thin | light | regular | bold | fill | duotone', default: 'regular', description: 'Icon weight/style' },
           { name: 'size', type: 'xs | sm | md | lg | xl | string', default: 'md', description: 'Size (named or custom CSS value)' },
           { name: 'color', type: 'string', default: 'currentColor', description: 'Icon color (inherits from parent by default)' },
@@ -45,6 +46,71 @@ const commonIcons = [
           { name: 'hidden', type: 'boolean', default: 'false', description: 'Hide the component' },
         ]"
       />
+    </div>
+
+    <div>
+      <h2 class="mb-4 text-2xl font-semibold">Tree-shaking</h2>
+      <CuiCard variant="outline">
+        <CuiCardBody>
+          <CuiStack spacing="4">
+            <p>
+              Phosphor ships ~1,500 Vue components. clean-ui statically imports only the
+              <strong>52 icons its own components draw</strong>, so that's all you pay for by
+              default. Icon names beyond that set need to reach your bundle somehow — the
+              library can't know them in advance.
+            </p>
+
+            <div>
+              <h3 class="mb-2 text-lg font-semibold">Register the icons you use</h3>
+              <p class="mb-2 text-sm" style="color: var(--cui-text-secondary)">
+                The recommended path: your static import is what makes it tree-shakeable.
+                Call it once, anywhere — app entry, a route module, a lazy feature.
+              </p>
+              <pre class="cui-pre"><code class="cui-code">import { registerIcons } from "@itguy614/clean-ui";
+import { PhRocket, PhGithubLogo } from "@phosphor-icons/vue";
+
+registerIcons({ rocket: PhRocket, "github-logo": PhGithubLogo });
+
+// then anywhere:
+&lt;CuiIcon name="rocket" /&gt;</code></pre>
+            </div>
+
+            <div>
+              <h3 class="mb-2 text-lg font-semibold">Or pass the component directly</h3>
+              <pre class="cui-pre"><code class="cui-code">import { PhRocket } from "@phosphor-icons/vue";
+
+&lt;CuiIcon :icon="PhRocket" /&gt;</code></pre>
+            </div>
+
+            <div>
+              <h3 class="mb-2 text-lg font-semibold">Or accept the whole package</h3>
+              <p class="mb-2 text-sm" style="color: var(--cui-text-secondary)">
+                One import makes any name resolve at runtime, as in clean-ui 1.0.x. Convenient
+                when icon names come from data and can't be enumerated — but it pulls in every
+                icon, measured on an app rendering a single icon:
+              </p>
+              <pre class="cui-pre"><code class="cui-code">import "@itguy614/clean-ui/icons/lazy";</code></pre>
+              <CuiFlex gap="6" class="mt-3 text-sm" wrap="wrap">
+                <div>
+                  <div style="color: var(--cui-text-secondary)">default</div>
+                  <div><strong>124 kB</strong> gzip · 52 icons</div>
+                </div>
+                <div>
+                  <div style="color: var(--cui-text-secondary)">with icons/lazy</div>
+                  <div><strong>1,315 kB</strong> gzip · the full set</div>
+                </div>
+              </CuiFlex>
+            </div>
+
+            <CuiAlert color="info" title="This site opts in">
+              The gallery below renders arbitrary Phosphor names to show what's available, so
+              the docs import <code class="cui-code">icons/lazy</code>. An unregistered name in
+              an app without it renders a <code class="cui-code">?</code> glyph and logs how to
+              register it.
+            </CuiAlert>
+          </CuiStack>
+        </CuiCardBody>
+      </CuiCard>
     </div>
 
     <div>

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -8,12 +8,18 @@ export default defineConfig({
   base: process.env.VITE_BASE ?? "/",
   plugins: [vue(), tailwindcss()],
   resolve: {
-    alias: {
-      "@itguy614/clean-ui": resolve(
-        __dirname,
-        "../../packages/clean-ui/src/index.ts",
-      ),
-    },
+    // Array form, longest find first: an object alias prefix-matches, so the bare
+    // package key would also swallow the "/icons/lazy" subpath.
+    alias: [
+      {
+        find: "@itguy614/clean-ui/icons/lazy",
+        replacement: resolve(__dirname, "../../packages/clean-ui/src/icons/lazy.ts"),
+      },
+      {
+        find: /^@itguy614\/clean-ui$/,
+        replacement: resolve(__dirname, "../../packages/clean-ui/src/index.ts"),
+      },
+    ],
   },
   server: {
     // Allow importing repo-root files (VERSION, CHANGELOG.md) via ?raw in dev.

--- a/packages/clean-ui/package.json
+++ b/packages/clean-ui/package.json
@@ -35,6 +35,10 @@
       "import": "./dist/index.js"
     },
     "./styles": "./dist/clean-ui.css",
+    "./icons/lazy": {
+      "types": "./dist/icons/lazy.d.ts",
+      "import": "./dist/icons/lazy.js"
+    },
     "./*": "./dist/*"
   },
   "files": [
@@ -43,7 +47,8 @@
     "LICENSE"
   ],
   "sideEffects": [
-    "**/*.css"
+    "**/*.css",
+    "./dist/icons/lazy.js"
   ],
   "scripts": {
     "build": "vite build && vue-tsc --emitDeclarationOnly && node scripts/postbuild.mjs",

--- a/packages/clean-ui/src/components/CuiIcon.vue
+++ b/packages/clean-ui/src/components/CuiIcon.vue
@@ -1,14 +1,32 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, watch, type Component } from "vue";
+import { shallowRef, computed, watchEffect, toRaw, type Component } from "vue";
 import type { CuiSize, CuiColorOrCss, HideableProps } from "../types/common";
 import { resolveColor } from "../utils/color";
+import {
+  resolveRegisteredIcon,
+  getIconFallbackResolver,
+  type IconFallbackResolver,
+} from "../icons/registry";
+import { FALLBACK_ICON } from "../icons/builtin";
+import { warnOnce } from "../utils/devWarn";
 
 export type IconWeight = "thin" | "light" | "regular" | "bold" | "fill" | "duotone";
 export type IconSize = CuiSize | (string & {});
 
 export interface CuiIconProps extends HideableProps {
-  /** Phosphor icon name in kebab-case (e.g. "check", "warning-circle", "eye-slash") */
-  name: string;
+  /**
+   * Phosphor icon name in kebab-case (e.g. "check", "warning-circle").
+   * Resolved from the built-in set and anything passed to `registerIcons()`.
+   * An unregistered name still renders, via a lazy import of the whole Phosphor
+   * package — which is not tree-shakeable, so it warns in the console.
+   */
+  name?: string;
+  /**
+   * A Phosphor component passed directly, e.g. `:icon="PhRocket"`. The simplest
+   * tree-shakeable path — the consumer's own static import. Takes precedence
+   * over `name`.
+   */
+  icon?: Component;
   /** Icon weight/style */
   weight?: IconWeight;
   /** Icon size — named scale (xs–xl) or custom CSS value */
@@ -45,40 +63,87 @@ function toPascalCase(name: string): string {
   return "Ph" + name.split("-").map((s) => s.charAt(0).toUpperCase() + s.slice(1)).join("");
 }
 
-// Cache resolved icon components so they're only loaded once per icon name
-const iconCache = new Map<string, Component>();
-const iconComponent = ref<Component | null>(null);
+/**
+ * Icons resolve in three steps:
+ *
+ * 1. `:icon` — a component handed straight to us.
+ * 2. `name` against the built-in set + `registerIcons()`. Synchronous, so the
+ *    icon renders on first paint and during SSR (both sides read the same static
+ *    map, so there's nothing to mismatch).
+ * 3. Neither — the fallback glyph, plus a warning naming the fix.
+ *
+ * There is deliberately NO `import("@phosphor-icons/vue")` here: a bundler that
+ * sees one has to keep all ~1500 icons, which is exactly the cost #42 is about
+ * (1315 kB gzip with it, 124 kB without). Consumers who want any-name resolution
+ * install a resolver by importing `@itguy614/clean-ui/icons/lazy`, which keeps
+ * the package out of every other bundle.
+ */
+// shallowRef, not ref: a plain ref deep-converts the component definition, which
+// makes Vue log "received a Component that was made a reactive object".
+const asyncResolved = shallowRef<Component | null>(null);
 
-// Resolve the icon for a given name. Runs in the browser only (called from
-// onMounted + a watcher) so the Phosphor import never executes on the server —
-// avoiding hydration mismatches. The `requested`/guard handles a reactive
-// `name` change whose async import resolves out of order.
-async function resolveIcon(name: string) {
-  const pascalName = toPascalCase(name);
+const staticIcon = computed<Component | null>(() => {
+  // toRaw: an icon held in reactive state arrives as a proxy, and rendering a
+  // reactive component definition makes Vue warn about the overhead.
+  if (props.icon) return toRaw(props.icon);
+  if (!props.name) return null;
+  return resolveRegisteredIcon(props.name) ?? null;
+});
 
-  if (iconCache.has(pascalName)) {
-    iconComponent.value = iconCache.get(pascalName)!;
-    return;
-  }
+const iconComponent = computed<Component | null>(() => staticIcon.value ?? asyncResolved.value);
 
+function warnUnknown(name: string) {
+  warnOnce(
+    `[CuiIcon] unknown icon "${name}". Register it so it ships with your bundle:\n` +
+      `  import { registerIcons } from "@itguy614/clean-ui";\n` +
+      `  import { ${toPascalCase(name)} } from "@phosphor-icons/vue";\n` +
+      `  registerIcons({ "${name}": ${toPascalCase(name)} });\n` +
+      `Or, to resolve any name at runtime (pulls in the whole icon package):\n` +
+      `  import "@itguy614/clean-ui/icons/lazy";`,
+  );
+}
+
+async function resolveViaFallback(name: string, resolver: IconFallbackResolver) {
   try {
-    const mod = await import("@phosphor-icons/vue");
-    let resolved = mod[pascalName as keyof typeof mod] as Component | undefined;
+    const resolved = await resolver(name);
     if (!resolved) {
-      console.warn(`[CuiIcon] Icon "${name}" (${pascalName}) not found in @phosphor-icons/vue`);
-      resolved = mod.PhQuestion as Component;
+      warnOnce(`[CuiIcon] Icon "${name}" (${toPascalCase(name)}) not found in @phosphor-icons/vue`);
     }
-    iconCache.set(pascalName, resolved);
-    // Ignore a stale resolution if `name` changed while we were importing.
-    if (props.name === name) iconComponent.value = resolved;
+    // Ignore a stale resolution if `name` changed while we were resolving.
+    if (props.name === name) asyncResolved.value = resolved ?? FALLBACK_ICON;
   } catch {
-    console.warn(`[CuiIcon] Failed to load icon "${name}"`);
+    warnOnce(`[CuiIcon] Failed to load icon "${name}"`);
+    if (props.name === name) asyncResolved.value = FALLBACK_ICON;
   }
 }
 
-onMounted(() => resolveIcon(props.name));
-// Re-resolve when the name prop changes (browser-only; onMounted has run).
-watch(() => props.name, (name) => resolveIcon(name));
+watchEffect(() => {
+  if (staticIcon.value || !props.name) {
+    asyncResolved.value = null;
+    return;
+  }
+
+  const resolver = getIconFallbackResolver();
+  if (!resolver) {
+    // Render the "?" glyph rather than nothing, so a typo is visible instead of
+    // silently blank — same as pre-1.1 behaviour for a bad name.
+    warnUnknown(props.name);
+    asyncResolved.value = FALLBACK_ICON;
+    return;
+  }
+
+  // A resolver can't complete during SSR; the placeholder covers the gap.
+  if (typeof window === "undefined") return;
+  resolveViaFallback(props.name, resolver);
+});
+
+// Unconditional, matching the rest of utils/devWarn: only genuine misuse
+// reaches it, and dev detection in a published ESM library is unreliable.
+watchEffect(() => {
+  if (!props.name && !props.icon) {
+    warnOnce("[CuiIcon] requires either a `name` or an `icon` prop.");
+  }
+});
 
 // Duotone CSS overrides
 const wrapperStyle = computed(() => {

--- a/packages/clean-ui/src/icons/__tests__/builtin.test.ts
+++ b/packages/clean-ui/src/icons/__tests__/builtin.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { BUILTIN_ICONS } from "../builtin";
+import { COLOR_ICON_MAP } from "../../utils/colorIconMap";
+
+const SRC = resolve(__dirname, "../..");
+
+function walk(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) return entry === "__tests__" ? [] : walk(path);
+    return [path];
+  });
+}
+
+/**
+ * Every icon the library can render must be in BUILTIN_ICONS — otherwise it
+ * silently falls back to importing all of @phosphor-icons/vue at runtime, which
+ * is the bug this map exists to prevent (#42). This test is the guard against
+ * that drifting back as components change.
+ */
+function staticIconUsages(): { name: string; where: string }[] {
+  const found: { name: string; where: string }[] = [];
+
+  for (const file of walk(SRC).filter((f) => f.endsWith(".vue"))) {
+    const src = readFileSync(file, "utf8");
+    const where = file.replace(SRC + "/", "");
+
+    for (const tag of src.match(/<CuiIcon\b[\s\S]*?\/?>/g) ?? []) {
+      // literal name="…" (not the :name binding)
+      const literal = tag.match(/(?<![:\w-])name="([a-z0-9-]+)"/);
+      if (literal) {
+        found.push({ name: literal[1], where });
+        continue;
+      }
+      // string literals inside a :name expression are reachable too,
+      // e.g. :name="copied ? 'check' : 'copy'"
+      const dynamic = tag.match(/:name="([^"]+)"/);
+      for (const quoted of dynamic?.[1].match(/'([a-z0-9-]+)'/g) ?? []) {
+        found.push({ name: quoted.slice(1, -1), where: `${where} (:name literal)` });
+      }
+    }
+  }
+  return found;
+}
+
+describe("built-in icon map", () => {
+  it("covers every icon name used statically in a component template", () => {
+    const usages = staticIconUsages();
+    // sanity-check the scanner itself still finds the usages
+    expect(usages.length).toBeGreaterThan(20);
+
+    const missing = usages
+      .filter((u) => !(u.name in BUILTIN_ICONS))
+      .map((u) => `"${u.name}" in ${u.where}`);
+
+    expect(missing, `add these to BUILTIN_ICONS as static imports:\n  ${missing.join("\n  ")}`)
+      .toEqual([]);
+  });
+
+  it("covers every COLOR_ICON_MAP value (CuiAlert / CuiToast / CuiBanner auto-icons)", () => {
+    const missing = Object.entries(COLOR_ICON_MAP)
+      .filter(([, icon]) => !(icon in BUILTIN_ICONS))
+      .map(([role, icon]) => `"${icon}" (role: ${role})`);
+
+    expect(missing).toEqual([]);
+  });
+
+  it.each([
+    // CuiFileUpload's fileIcon()
+    ["file", "file-pdf", "file-zip", "file-xls", "file-doc", "file-text", "image", "video-camera", "music-note"],
+    // CuiDataGrid's getSortIcon()
+    ["caret-up", "caret-down", "caret-up-down"],
+    // CuiRating icon / halfIcon defaults
+    ["star", "star-half"],
+    // CuiConfirmDialog's per-color cfg.icon
+    ["warning", "warning-circle", "info"],
+    // CuiIcon's own unknown-name fallback
+    ["question"],
+  ])("covers the dynamic helper set %#", (...names) => {
+    const missing = names.filter((n) => !(n in BUILTIN_ICONS));
+    expect(missing).toEqual([]);
+  });
+
+  it("maps every name to a real component", () => {
+    const broken = Object.entries(BUILTIN_ICONS)
+      .filter(([, component]) => !component)
+      .map(([name]) => name);
+
+    expect(broken).toEqual([]);
+  });
+
+  it("uses kebab-case keys, matching what the name prop takes", () => {
+    const wrong = Object.keys(BUILTIN_ICONS).filter((k) => !/^[a-z0-9]+(-[a-z0-9]+)*$/.test(k));
+    expect(wrong).toEqual([]);
+  });
+});

--- a/packages/clean-ui/src/icons/__tests__/registry.test.ts
+++ b/packages/clean-ui/src/icons/__tests__/registry.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { defineComponent, h, nextTick } from "vue";
+import CuiIcon from "../../components/CuiIcon.vue";
+import {
+  registerIcons,
+  hasIcon,
+  registeredIconNames,
+  __clearRegisteredIcons,
+  setIconFallbackResolver,
+  getIconFallbackResolver,
+} from "../registry";
+
+/** Stand-in for a Phosphor icon component. */
+const FakeIcon = defineComponent({
+  name: "FakeIcon",
+  props: { weight: String, size: String, color: String },
+  setup: () => () => h("svg", { "data-fake": "true" }),
+});
+
+afterEach(() => {
+  __clearRegisteredIcons();
+  vi.restoreAllMocks();
+});
+
+describe("registerIcons", () => {
+  it("makes a name resolvable without the lazy import", () => {
+    expect(hasIcon("rocket")).toBe(false);
+    registerIcons({ rocket: FakeIcon });
+    expect(hasIcon("rocket")).toBe(true);
+  });
+
+  it("lists registered names alongside the built-ins", () => {
+    registerIcons({ rocket: FakeIcon });
+    const names = registeredIconNames();
+    expect(names).toContain("rocket");
+    expect(names).toContain("check"); // built-in
+  });
+
+  it("lets a registration override a built-in of the same name", () => {
+    const wrapper = mount(CuiIcon, { props: { name: "check" } });
+    expect(wrapper.find("[data-fake]").exists()).toBe(false);
+
+    registerIcons({ check: FakeIcon });
+    const after = mount(CuiIcon, { props: { name: "check" } });
+    expect(after.find("[data-fake]").exists()).toBe(true);
+  });
+
+  it("re-resolves an already-rendered icon when its name is registered later", async () => {
+    const wrapper = mount(CuiIcon, { props: { name: "rocket" } });
+    // unresolved at first: placeholder, no svg from the registry
+    expect(wrapper.find("[data-fake]").exists()).toBe(false);
+
+    registerIcons({ rocket: FakeIcon });
+    await nextTick();
+
+    expect(wrapper.find("[data-fake]").exists()).toBe(true);
+  });
+});
+
+describe("CuiIcon resolution", () => {
+  it("renders a built-in name synchronously — no await needed", () => {
+    // The point of the static map: an icon is present on first render, which is
+    // also what lets it render during SSR.
+    const wrapper = mount(CuiIcon, { props: { name: "check" } });
+    expect(wrapper.find("svg").exists()).toBe(true);
+    expect(wrapper.find(".cui-icon__placeholder").exists()).toBe(false);
+  });
+
+  it("renders a component passed via the icon prop, taking precedence over name", () => {
+    const wrapper = mount(CuiIcon, { props: { name: "check", icon: FakeIcon } });
+    expect(wrapper.find("[data-fake]").exists()).toBe(true);
+  });
+
+  it("renders the fallback glyph for an unknown name when no resolver is installed", () => {
+    const wrapper = mount(CuiIcon, { props: { name: "definitely-not-an-icon" } });
+    // "?" rather than a blank box, so a typo is visible
+    expect(wrapper.find("svg").exists()).toBe(true);
+    expect(wrapper.find(".cui-icon__placeholder").exists()).toBe(false);
+  });
+
+  it("warns for an unknown name, naming both remedies", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // A name no other test has mounted: the warning is once-per-message, so a
+    // reused name would already have been emitted and deduped.
+    mount(CuiIcon, { props: { name: "paper-plane-tilt" } });
+    await flushPromises();
+
+    const message = warn.mock.calls.flat().join("\n");
+    expect(message).toContain('registerIcons({ "paper-plane-tilt": PhPaperPlaneTilt })');
+    expect(message).toContain("@itguy614/clean-ui/icons/lazy");
+  });
+
+  it("does not warn for a built-in name", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mount(CuiIcon, { props: { name: "check" } });
+    await flushPromises();
+
+    expect(warn.mock.calls.flat().join("\n")).not.toContain("unknown icon");
+  });
+
+  it("switches synchronously when the name prop changes between built-ins", async () => {
+    const wrapper = mount(CuiIcon, { props: { name: "check" } });
+    const first = wrapper.find("svg").html();
+
+    await wrapper.setProps({ name: "x" });
+    expect(wrapper.find("svg").html()).not.toBe(first);
+  });
+});
+
+describe("opt-in fallback resolver", () => {
+  it("resolves an unregistered name once a resolver is installed", async () => {
+    setIconFallbackResolver(async (name) => (name === "rocket" ? FakeIcon : undefined));
+    const wrapper = mount(CuiIcon, { props: { name: "rocket" } });
+
+    // async: the placeholder holds the space until the resolver settles
+    expect(wrapper.find(".cui-icon__placeholder").exists()).toBe(true);
+    await flushPromises();
+    expect(wrapper.find("[data-fake]").exists()).toBe(true);
+
+    setIconFallbackResolver(null);
+  });
+
+  it("falls back to the glyph when the resolver yields nothing", async () => {
+    setIconFallbackResolver(async () => undefined);
+    const wrapper = mount(CuiIcon, { props: { name: "nope-not-real" } });
+    await flushPromises();
+
+    expect(wrapper.find("svg").exists()).toBe(true);
+    setIconFallbackResolver(null);
+  });
+
+  it("survives a resolver that rejects", async () => {
+    setIconFallbackResolver(async () => {
+      throw new Error("network down");
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const wrapper = mount(CuiIcon, { props: { name: "offline-icon" } });
+    await flushPromises();
+
+    expect(wrapper.find("svg").exists()).toBe(true);
+    expect(warn.mock.calls.flat().join("\n")).toContain('Failed to load icon "offline-icon"');
+    setIconFallbackResolver(null);
+  });
+
+  it("prefers a registered icon over the resolver", async () => {
+    const resolver = vi.fn(async () => FakeIcon);
+    setIconFallbackResolver(resolver);
+    mount(CuiIcon, { props: { name: "check" } }); // built-in
+    await flushPromises();
+
+    expect(resolver).not.toHaveBeenCalled();
+    setIconFallbackResolver(null);
+  });
+
+  it("icons/lazy installs a resolver on import", async () => {
+    const { enableLazyIcons, disableLazyIcons } = await import("../lazy");
+    disableLazyIcons();
+    expect(getIconFallbackResolver()).toBeNull();
+
+    enableLazyIcons();
+    expect(getIconFallbackResolver()).toBeTypeOf("function");
+    disableLazyIcons();
+  });
+});

--- a/packages/clean-ui/src/icons/builtin.ts
+++ b/packages/clean-ui/src/icons/builtin.ts
@@ -1,0 +1,145 @@
+/**
+ * Every icon the library's own components can render, imported statically.
+ *
+ * Static named imports are the only shape `@phosphor-icons/vue` can tree-shake:
+ * it ships no per-icon entry points, and the previous
+ * `(await import("@phosphor-icons/vue"))[computedKey]` lookup forced bundlers to
+ * retain all ~1500 icons. Listing the bounded set here caps what a consumer can
+ * possibly pay for at what clean-ui actually draws.
+ *
+ * Every entry in this object is reachable, so bundlers keep all of them — that's
+ * the deliberate trade: ~50 icons, zero configuration. Consumers add their own
+ * with `registerIcons()` (tree-shakeable, since they import statically too) or
+ * pass a component straight to `<CuiIcon :icon="PhFoo" />`.
+ *
+ * `src/icons/__tests__/builtin.test.ts` scans the components and the dynamic
+ * lookup tables and fails if a name the library can render is missing here, so
+ * this can't silently drift back to the full-set import.
+ */
+import {
+  PhArrowCounterClockwise,
+  PhBookmarkSimple,
+  PhCalendarBlank,
+  PhCaretDoubleLeft,
+  PhCaretDoubleRight,
+  PhCaretDown,
+  PhCaretLeft,
+  PhCaretRight,
+  PhCaretUp,
+  PhCaretUpDown,
+  PhCheck,
+  PhCheckCircle,
+  PhCircle,
+  PhCircleNotch,
+  PhClock,
+  PhCloudArrowUp,
+  PhColumns,
+  PhCopy,
+  PhDotsNine,
+  PhDotsSixVertical,
+  PhDotsThree,
+  PhEye,
+  PhEyeSlash,
+  PhFile,
+  PhFileDoc,
+  PhFilePdf,
+  PhFileText,
+  PhFileXls,
+  PhFileZip,
+  PhFloppyDisk,
+  PhFunnel,
+  PhImage,
+  PhInfo,
+  PhMagnifyingGlass,
+  PhMinus,
+  PhMusicNote,
+  PhPlus,
+  PhPushPin,
+  PhQuestion,
+  PhSpinnerGap,
+  PhSquaresFour,
+  PhStar,
+  PhStarHalf,
+  PhTable,
+  PhTrash,
+  PhUploadSimple,
+  PhUser,
+  PhVideoCamera,
+  PhWarning,
+  PhWarningCircle,
+  PhX,
+  PhXCircle,
+} from "@phosphor-icons/vue";
+import type { Component } from "vue";
+
+/** kebab-case icon name → Phosphor component. */
+export const BUILTIN_ICONS: Record<string, Component> = {
+  // --- Carets / navigation ---
+  "caret-down": PhCaretDown,
+  "caret-left": PhCaretLeft,
+  "caret-right": PhCaretRight,
+  "caret-up": PhCaretUp,
+  "caret-up-down": PhCaretUpDown, // CuiDataGrid unsorted column
+  "caret-double-left": PhCaretDoubleLeft,
+  "caret-double-right": PhCaretDoubleRight,
+
+  // --- Controls / actions ---
+  check: PhCheck,
+  copy: PhCopy,
+  "dots-nine": PhDotsNine,
+  "dots-six-vertical": PhDotsSixVertical,
+  "dots-three": PhDotsThree,
+  eye: PhEye,
+  "eye-slash": PhEyeSlash,
+  "floppy-disk": PhFloppyDisk,
+  funnel: PhFunnel,
+  "magnifying-glass": PhMagnifyingGlass,
+  minus: PhMinus,
+  plus: PhPlus,
+  "push-pin": PhPushPin,
+  trash: PhTrash,
+  "upload-simple": PhUploadSimple,
+  x: PhX,
+  "arrow-counter-clockwise": PhArrowCounterClockwise,
+  "bookmark-simple": PhBookmarkSimple,
+
+  // --- Status (COLOR_ICON_MAP + CuiConfirmDialog) ---
+  "check-circle": PhCheckCircle,
+  info: PhInfo,
+  warning: PhWarning,
+  "warning-circle": PhWarningCircle,
+  "x-circle": PhXCircle,
+
+  // --- Structure / display ---
+  "calendar-blank": PhCalendarBlank,
+  circle: PhCircle,
+  "circle-notch": PhCircleNotch,
+  clock: PhClock,
+  columns: PhColumns,
+  "spinner-gap": PhSpinnerGap,
+  "squares-four": PhSquaresFour,
+  table: PhTable,
+  user: PhUser,
+
+  // --- CuiRating defaults ---
+  star: PhStar,
+  "star-half": PhStarHalf,
+
+  // --- CuiFileUpload's fileIcon() ---
+  "cloud-arrow-up": PhCloudArrowUp,
+  file: PhFile,
+  "file-doc": PhFileDoc,
+  "file-pdf": PhFilePdf,
+  "file-text": PhFileText,
+  "file-xls": PhFileXls,
+  "file-zip": PhFileZip,
+  image: PhImage,
+  "music-note": PhMusicNote,
+  "video-camera": PhVideoCamera,
+
+  // --- Fallback for an unknown name ---
+  question: PhQuestion,
+};
+
+/** Rendered when a name can't be resolved at all. */
+export const FALLBACK_ICON = PhQuestion;

--- a/packages/clean-ui/src/icons/lazy.ts
+++ b/packages/clean-ui/src/icons/lazy.ts
@@ -1,0 +1,54 @@
+/**
+ * Opt-in lazy icon loading.
+ *
+ * ```ts
+ * import "@itguy614/clean-ui/icons/lazy";
+ * ```
+ *
+ * Installs a fallback resolver so ANY Phosphor icon name works without being
+ * registered, matching clean-ui ≤1.0.1 behaviour. Convenient for prototypes and
+ * for apps whose icon names are data-driven and unbounded.
+ *
+ * The cost is the whole point of keeping this in its own module: the dynamic
+ * import below makes bundlers retain every icon in the package. Measured on an
+ * app rendering a single icon — 124 kB gzip without this module, 1315 kB with it.
+ * So don't reach for it to silence a warning; register the handful of names you
+ * actually use instead:
+ *
+ * ```ts
+ * import { registerIcons } from "@itguy614/clean-ui";
+ * import { PhRocket } from "@phosphor-icons/vue";
+ * registerIcons({ rocket: PhRocket });
+ * ```
+ */
+import type { Component } from "vue";
+import { setIconFallbackResolver } from "./registry";
+
+function toPascalCase(name: string): string {
+  return "Ph" + name.split("-").map((s) => s.charAt(0).toUpperCase() + s.slice(1)).join("");
+}
+
+const cache = new Map<string, Component | undefined>();
+
+/**
+ * Enable lazy resolution. Called automatically when this module is imported;
+ * exported as well so the intent can be explicit at a call site.
+ */
+export function enableLazyIcons(): void {
+  setIconFallbackResolver(async (name) => {
+    const pascalName = toPascalCase(name);
+    if (cache.has(pascalName)) return cache.get(pascalName);
+
+    const mod = await import("@phosphor-icons/vue");
+    const resolved = mod[pascalName as keyof typeof mod] as Component | undefined;
+    cache.set(pascalName, resolved);
+    return resolved;
+  });
+}
+
+/** Undo {@link enableLazyIcons} — unregistered names go back to the fallback glyph. */
+export function disableLazyIcons(): void {
+  setIconFallbackResolver(null);
+}
+
+enableLazyIcons();

--- a/packages/clean-ui/src/icons/registry.ts
+++ b/packages/clean-ui/src/icons/registry.ts
@@ -1,0 +1,76 @@
+import { shallowReactive, type Component } from "vue";
+import { BUILTIN_ICONS } from "./builtin";
+
+/**
+ * Icon registry — the tree-shakeable path for icons beyond the built-in set.
+ *
+ * Consumers statically import the Phosphor components they use and register them
+ * by the same kebab-case name they pass to `<CuiIcon name="…" />`, so their
+ * bundler sees a real static reference and ships only those icons:
+ *
+ * ```ts
+ * import { registerIcons } from "@itguy614/clean-ui";
+ * import { PhRocket, PhGithubLogo } from "@phosphor-icons/vue";
+ *
+ * registerIcons({ rocket: PhRocket, "github-logo": PhGithubLogo });
+ * ```
+ *
+ * Module-level on purpose: callable from an app entry, a route module, or a
+ * lazily-loaded feature, with no app instance or component context needed.
+ * Sharing it across SSR requests is safe — icon components are stateless.
+ */
+
+// shallowReactive so a registration after a CuiIcon has already rendered
+// re-resolves it, without Vue walking into the component definitions.
+const registered = shallowReactive<Record<string, Component>>({});
+
+/**
+ * Register icons by name. Later calls override earlier ones for the same name,
+ * and a registered name also overrides the built-in of that name.
+ */
+export function registerIcons(icons: Record<string, Component>): void {
+  Object.assign(registered, icons);
+}
+
+/** Look a name up: registered first, then the library's built-in set. */
+export function resolveRegisteredIcon(name: string): Component | undefined {
+  return registered[name] ?? BUILTIN_ICONS[name];
+}
+
+/** Whether a name resolves without the lazy fallback (i.e. is tree-shakeable). */
+export function hasIcon(name: string): boolean {
+  return resolveRegisteredIcon(name) !== undefined;
+}
+
+/** Names currently resolvable statically — built-in plus registered. */
+export function registeredIconNames(): string[] {
+  return [...new Set([...Object.keys(BUILTIN_ICONS), ...Object.keys(registered)])].sort();
+}
+
+/** Test seam: drop consumer registrations, leaving the built-ins. */
+export function __clearRegisteredIcons(): void {
+  for (const key of Object.keys(registered)) delete registered[key];
+}
+
+/**
+ * Resolver consulted for a name that is neither built-in nor registered.
+ *
+ * Deliberately a hook rather than a dynamic `import()` inside CuiIcon: a bundler
+ * that sees `import("@phosphor-icons/vue")` anywhere must keep all ~1500 icons,
+ * which is the very cost #42 is about — measured at 1315 kB gzip versus 124 kB
+ * once the import is gone. Keeping it in a separate module that nothing imports
+ * by default means the package only enters a bundle if the consumer asks for it,
+ * via `@itguy614/clean-ui/icons/lazy`.
+ */
+export type IconFallbackResolver = (name: string) => Promise<Component | undefined>;
+
+let fallbackResolver: IconFallbackResolver | null = null;
+
+/** Install a resolver for unregistered names. See `icons/lazy`. */
+export function setIconFallbackResolver(resolver: IconFallbackResolver | null): void {
+  fallbackResolver = resolver;
+}
+
+export function getIconFallbackResolver(): IconFallbackResolver | null {
+  return fallbackResolver;
+}

--- a/packages/clean-ui/src/index.ts
+++ b/packages/clean-ui/src/index.ts
@@ -279,6 +279,18 @@ export type {
 } from "./types/grid";
 
 // Composable exports
+// Icon registry — register statically-imported Phosphor icons so they tree-shake.
+// The lazy any-name resolver is NOT re-exported here on purpose: importing it
+// would pull the whole icon package into every consumer bundle. It lives at
+// "@itguy614/clean-ui/icons/lazy".
+export {
+  registerIcons,
+  hasIcon,
+  registeredIconNames,
+  setIconFallbackResolver,
+  type IconFallbackResolver,
+} from "./icons/registry";
+export { BUILTIN_ICONS } from "./icons/builtin";
 export { useTheme, THEME_PRESETS, type ThemePreset } from "./composables/useTheme";
 export { useDensity, DENSITY_PRESETS, type DensityId, type DensityPreset } from "./composables/useDensity";
 export { ssrThemeInitScript } from "./ssr-theme-init";

--- a/packages/clean-ui/vite.config.ts
+++ b/packages/clean-ui/vite.config.ts
@@ -7,8 +7,11 @@ export default defineConfig({
   plugins: [vue(), tailwindcss()],
   build: {
     lib: {
-      entry: resolve(__dirname, "src/index.ts"),
-      name: "CleanUI",
+      // Two entries: the barrel, plus the opt-in lazy icon resolver. The latter
+      // is unreachable from the barrel by design (importing it would drag the
+      // whole icon package into every consumer bundle), so it needs its own
+      // entry or Rollup never emits it for the "./icons/lazy" export.
+      entry: [resolve(__dirname, "src/index.ts"), resolve(__dirname, "src/icons/lazy.ts")],
       formats: ["es"],
     },
     rollupOptions: {


### PR DESCRIPTION
## Problem

`CuiIcon` resolved names with `(await import("@phosphor-icons/vue"))[computedKey]` — a computed lookup into the full module namespace. No bundler can see through that, so every consumer shipped all ~1500 icons.

## What changed

Icons resolve from a **static map of the 52 names the library's own components draw**, plus a registry consumers add to:

```ts
import { registerIcons } from "@itguy614/clean-ui";
import { PhRocket } from "@phosphor-icons/vue";
registerIcons({ rocket: PhRocket });     // their static import, so it shakes

<CuiIcon :icon="PhRocket" />             // or pass the component directly
```

**Breaking:** an unregistered name renders the `?` glyph and logs how to fix it. One import restores the old any-name behaviour for apps whose icon names come from data:

```ts
import "@itguy614/clean-ui/icons/lazy";
```

## Why the fallback had to move out of CuiIcon

This is the part worth reviewing. Keeping a lazy `import("@phosphor-icons/vue")` inside `CuiIcon` — which is what I originally planned — would have cost the **entire** saving, because a bundler that sees that import must retain every icon whether or not it's ever reached. Measured by bundling an app that renders a single icon:

| library variant | chunks | raw | gzip | icons shipped |
| --- | --- | --- | --- | --- |
| `develop` (1.0.1) | 3 | 6795 kB | 1306 kB | 1513 |
| static map **+ in-component lazy fallback** | 3 | 6796 kB | **1315 kB** | **1513** |
| static map, fallback in its own module | 1 | 480 kB | **124 kB** | **52** |
| …plus `import "…/icons/lazy"` | 3 | 6797 kB | 1315 kB | 1513 |
| …plus `registerIcons({ rocket })` | 1 | — | +2 kB | **53** |

So: 10.5× smaller by default, the escape hatch returns you exactly to the old cost, and registering an icon adds only that icon.

`icons/lazy` needs its own **build entry** — nothing in the barrel imports it (deliberately), so Rollup wouldn't emit it for the `./icons/lazy` export — and its own `sideEffects` entry so the bare import isn't dropped.

## Also in here

- **SSR / first paint:** static resolution is synchronous, so mapped icons render in SSR output and on first paint. The placeholder now only covers the opt-in async path, and the `onMounted` hydration workaround from #28 is gone.
- **Pre-existing warning fixed:** the resolved component was held in a plain `ref`, so every icon render logged *"Vue received a Component that was made a reactive object"*. Now `shallowRef` + `toRaw`.
- **Drift guard:** `src/icons/__tests__/builtin.test.ts` scans component templates and the dynamic lookup tables (`COLOR_ICON_MAP`, `fileIcon()`, `getSortIcon()`, rating defaults) and fails naming the file if an icon the library renders is missing from the map. `CLAUDE.md` carries the same rule for new components.
- **Docs:** the site opts into `icons/lazy`, because its gallery renders arbitrary names to show what Phosphor offers — exactly the unbounded case the hatch is for, and it's disclosed on the page. The Icons page documents all three paths with these numbers, and `icon` is in the prop table.

## Verification

Browser checks against the real built bundles, not just unit tests:

- unregistered name, no opt-in → renders PhQuestion (`M140,180a12,12,0,1,1-12-`), no errors, and one warning naming both `registerIcons({ … })` and `@itguy614/clean-ui/icons/lazy`
- docs Icons page → 125 `CuiIcon`s, 125 rendered, 0 placeholders, 85 distinct glyphs
- docs Tree-shaking section screenshotted; code samples render real angle brackets and the stated figures match the measurements (I corrected "~50/53 icons" to the exact 52 after counting the map)

24 new tests in `src/icons/__tests__/`. Full suite 426 passed / 18 skipped, 38/38 files. Library and docs builds clean.

## Note for the release

The issue targets this at 1.1.0. It's breaking for consumers passing names outside the built-in set, with a one-line remedy — worth calling out prominently in the release notes.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)