### PR TITLE
docs: markdown editor specification, platform requirements and implementation plans

### DIFF
--- a/docs/features/markdown-editor.md
+++ b/docs/features/markdown-editor.md
@@ -1,0 +1,471 @@
+# Feature: Markdown Editor (@itguy614/clean-ui-editor)
+
+**Status**: Draft
+**Created**: 2026-07-29
+
+## Problem Statement
+
+### Current State
+
+clean-ui ships form controls for single- and multi-line text (`CuiInput`, `CuiTextarea`) and
+a read-only `CuiCodeBlock`. There is no way to author formatted content. An app that needs
+notes, comments, release notes or descriptions has three options today: a bare textarea in
+which users hand-write markdown with no assistance, a third-party editor whose look and
+theming diverge from clean-ui, or plain text with no formatting at all.
+
+Markdown-capable editors that would fit visually all carry costs clean-ui deliberately
+avoids: their own design systems, large dependency graphs, and no awareness of clean-ui's
+tokens, dark mode, density scale or message catalog.
+
+### Desired State
+
+A published, documented editor component that drops into a form like any other clean-ui
+control, lets users format content without knowing markdown syntax, still lets
+markdown-literate users work in raw source, and can be extended by consumers without forking
+it.
+
+### Gap
+
+The library has no content-authoring primitive, and no extension point through which an
+application can add its own authoring actions (for example inserting a timestamp, a
+template, or an app-specific reference).
+
+## Design Decisions
+
+Settled before drafting; these constrain the requirements below.
+
+| Decision | Choice | Why |
+| --- | --- | --- |
+| Document model | Markdown text is the single source of truth, edited in CodeMirror 6 | No markdown-to-document conversion exists, so round-trip fidelity cannot drift and source mode is the same buffer with decorations disabled |
+| WYSIWYG rendering | Syntax markers hidden until the cursor enters the construct | Reads as formatted prose while every character remains editable text |
+| Reveal granularity | Construct-level for pointer input, line-level for touch | Landing a fingertip between two asterisks is not a reasonable requirement; a line is a comfortable touch target |
+| Accessible text | Markers are hidden visually only; the full markdown always remains in the accessibility tree | Nothing is ever concealed from assistive technology, and the characters a screen reader announces are exactly the ones the caret moves through |
+| Dialect | CommonMark plus GFM (tables, task lists, strikethrough, autolinks) | Lezer ships this as a ready parser extension; matches what GitHub and most CMSes accept |
+| Plugin API | Declarative tier (commands, toolbar, keymap, constructs, paste rules, decoration rules) plus a raw CodeMirror extension escape hatch | Covers ordinary actions without leaking CodeMirror, while leaving ambitious plugins possible. The declarative tier must be able to express everything the built-ins need, or the built-ins become privileged and the tier is untested |
+| Command execution | Commands are synchronous and return a boolean, as CodeMirror's own commands do; asynchronous work goes through named seams the editor owns | Positions go stale across an `await` and undo grouping becomes undefined; the editor should absorb that once rather than distribute it to every plugin author |
+| API stability tiers | Declarative tier is semver-major protected; the raw tier tracks the CodeMirror major it is built against and may break in an editor minor | The escape hatch's price, stated openly, so CodeMirror's release cadence cannot dictate ours |
+| Built-in actions | Implemented as plugins against the public plugin API and shipped as presets | Proves the API is sufficient, makes the documentation examples the library's own source, and lets an application omit what it does not use |
+| Construct policy | The loaded plugin set defines which constructs are allowed; commands, slash menu, paste conversion and decoration all honour it | Excluding a plugin should mean the construct cannot enter the document, not merely that a button is hidden |
+| Plugin precedence | Array order, default preset applied first, later registration wins, conflicts warned | Makes overriding a built-in possible on purpose, and makes an accidental clash visible instead of order-dependent and silent |
+| Form integration | Composes `FormControlProps` and participates in `CuiForm` like every other control | A markdown field is a form field; validation errors and helper text need the same home they have on `CuiInput` |
+| Rendering to HTML | Injectable `render` adapter; the library's own implementation is an optional `/render` battery with raw HTML escaped by default | The editor needs no HTML at any phase, and an app that already renders markdown elsewhere must not end up with two renderers and two sanitiser policies over the same content |
+| Modes | `wysiwyg` and `source`, with a built-in toggle | One boolean over one buffer; split preview additionally needs a renderer and is deferred |
+| Toolbar | Default preset, `toolbar` prop to subset and order by command id, `#toolbar` slot to replace | Configuration by id is what lets a plugin's action appear without touching the component |
+| Slash menu | `/` opens a filtered palette of insert commands, including plugin commands | Same declaration that produces a toolbar button produces a palette entry |
+| Images in v1 | Authored by URL only; pasted or dropped image files are refused with a message | Deferring uploads removes all asynchronous work from v1, and with it pending state, range mapping through concurrent edits, failure and retry, and saving mid-upload |
+| Tables in v1 | Parsed, highlighted and rendered, but no insert action and no cell navigation | Shipping an insert button without Tab between cells advertises an experience that is not there; the whole table feature lands together in phase 2 |
+| Packaging | `packages/clean-ui-editor` in this monorepo, clean-ui as a peer dependency, own docs app | clean-ui holds module-level singletons (icon registry, theme, density); a second copy would split that state |
+
+## Requirements
+
+### Functional Requirements
+
+**Value, editing and modes**
+
+- FR1: `v-model` is a markdown string. The component never rewrites content the user did not
+  edit, including unknown or non-standard syntax.
+- FR2: An incoming `modelValue` equal to the editor's current document is a no-op. Without
+  this, a host that echoes the value back mid-throttle resets the cursor and selection.
+- FR3: `v-model:mode` switches between `wysiwyg` and `source`. Switching preserves the
+  document, cursor position, selection and undo history.
+- FR4: In `source` mode the raw markdown is shown with syntax highlighting and nothing hidden.
+- FR5: A built-in mode toggle renders in the toolbar and can be suppressed so the host
+  application drives `mode` itself.
+- FR6: A `placeholder` prop renders in the empty state, consistent with `CuiInput` and
+  `CuiTextarea`.
+
+**Reveal model**
+
+- FR7: With pointer input, a construct's markers are hidden until the cursor or selection
+  enters that construct, then revealed for editing.
+- FR8: With touch input, a caret anywhere on a line reveals every marker on that line. The
+  active granularity follows the most recent input type, so hybrid devices behave sensibly.
+- FR9: Hiding is visual only. The complete markdown text, markers included, remains in the
+  accessibility tree, which rules out removing the characters from the DOM as the hiding
+  mechanism.
+- FR10: Reveal recalculation is suspended while an IME composition is active, so composition is
+  never interrupted or repositioned. CodeMirror exposes this as `view.composing`.
+- FR10a: Reveal recalculation is additionally triggered by a granularity change, not only by
+  document, selection and viewport changes. Granularity lives in editor state, and changing it
+  sets none of those flags — the spike found that switching from pointer to touch silently kept
+  the previous decorations until something else happened to invalidate them.
+
+**Formatting actions**
+
+- FR11: Actions with toolbar entries and keyboard shortcuts exist for: bold, italic,
+  strikethrough, inline code, headings 1 to 3, bulleted list, numbered list, task list,
+  blockquote, code fence, link, image by URL, and horizontal rule. Each is provided by a
+  built-in plugin written against the public plugin API (FR17), not privileged internal code.
+- FR12: Each action is a toggle where markdown allows it: applying it to an already-formatted
+  selection removes the formatting.
+- FR13: Applying an action with an empty selection inserts the markers and places the cursor
+  between them.
+- FR14: Link and image insertion collect values through a dialog built from clean-ui
+  components. A selection that looks like a URL pre-fills the URL field; any other selection
+  becomes the link label rather than being discarded. Mode switching is blocked while the
+  dialog is open.
+- FR15: Every command's document changes form exactly one undo step, however many edits it
+  makes internally.
+
+**Typing ergonomics**
+
+- FR16: List behaviour: Enter continues the current item; Enter on an empty item exits the
+  list; Tab and Shift-Tab indent and outdent; task items continue unchecked; ordered lists
+  renumber.
+
+**Plugin system**
+
+- FR17: A plugin is declared with a single factory (`definePlugin`) exposing a unique `id`,
+  named `commands`, and optionally: `toolbar` entries, a `keymap`, the `constructs` it
+  authorises, `paste` rules (source element to markdown emitter, each with an explicit degrade
+  target for FR28), `decorations` rules (parser node to marker-hiding behaviour), and raw
+  CodeMirror `extensions`. The declarative fields are sufficient for every built-in, so no
+  built-in needs privileged internal access.
+- FR18: A command is synchronous and returns a boolean indicating whether it handled the
+  invocation. It receives a context object with at minimum the current selection, the document
+  text, and helpers to insert at the cursor, wrap the selection and replace a range. These are
+  the same helpers the built-in actions use.
+- FR18a: Asynchronous work goes through named seams on the context rather than async commands.
+  `collect()` opens a dialog and resolves with values, and is used by FR14 in v1 so the seam is
+  proven before anything else depends on it. Phase 2 adds a reservation seam whose handle is
+  position-mapped through subsequent edits. FR15's single-undo-step guarantee applies per
+  transaction, not across an interaction that awaits a user.
+- FR19: A command may expose an `isActive` query so the toolbar can render pressed state and
+  the command can decide toggle-on versus toggle-off. Built-in toggles (FR12) rely on it.
+- FR20: Plugin toolbar entries and commands are addressable by id from the `toolbar` prop, and
+  appear in the slash menu when they carry a label and icon.
+- FR21: Precedence is the order of the `plugins` array with the default preset applied first,
+  so a later registration overrides an earlier one. Duplicate plugin ids, duplicate command
+  ids and conflicting keybindings emit a developer warning naming both contributors. Note this
+  is the opposite of CodeMirror's keymap semantics, where the first handler returning true wins,
+  so the mapping is implemented deliberately rather than by passing the array through. A raw
+  extension using an explicit precedence override escapes this model, which is documented.
+- FR21a: A plugin whose command throws does not break the editor. Every invocation path
+  (toolbar, keymap, slash menu, imperative API) is guarded, the failure surfaces through an
+  error hook naming the plugin, and editing continues. The raw tier is explicitly not
+  sandboxed — CodeMirror offers no such isolation — so each plugin's raw extensions are
+  installed separately, allowing a failing one to be dropped without remounting.
+- FR22: The `plugins` prop is reactive: changing it reconfigures the derived toolbar, commands,
+  keymap, construct policy and CodeMirror extensions in place, preserving the document, undo
+  history and cursor. The replacement configuration is built and validated **before** it is
+  applied; if it is invalid the previous configuration is kept and the failure is reported,
+  because a failed reconfiguration would otherwise leave a dead editor holding the user's
+  document. Documentation warns that plugin instances should be created once rather than inline
+  in a template.
+- FR22a: `definePlugin` stamps the plugin API version it was built against, and registration
+  rejects an incompatible plugin with a message naming the mismatch rather than failing later
+  at a missing helper.
+- FR23: The reference `timestamp` plugin ships in the docs as the worked example of the
+  declarative tier, and a second example uses the raw CodeMirror tier.
+- FR24: The component exposes an imperative API for host applications that do not want to
+  author a plugin: at minimum `el`, `focus`, `blur`, `runCommand(id, args?)`, `getSelection()`
+  and `getView()`. The raw view is reached through that single named accessor rather than a
+  reactive property, and every CodeMirror type the public API mentions is re-exported from this
+  package so a consumer's type-checker never resolves CodeMirror itself.
+- FR24a: Raw-tier plugin authors obtain CodeMirror through
+  `@itguy614/clean-ui-editor/codemirror`, which re-exports the surface they need. This is the
+  documented path because it makes a single CodeMirror instance the default rather than
+  something consumers must arrange. See `docs/platform/multi-package-build-and-release.md` for
+  the detection and CI enforcement that backs it.
+
+**Composition and construct policy**
+
+- FR25: Built-in plugins are exported individually and as presets, including a default preset
+  used when `plugins` is not supplied, so zero-configuration usage yields a complete editor.
+- FR26: An application can compose its own set by listing plugins explicitly, extending the
+  default preset, or configuring a preset to omit individual actions.
+- FR27: A construct whose plugin is not loaded is absent from every authoring surface: no
+  toolbar button, no keyboard shortcut, no slash-menu entry, no command.
+- FR28: Paste conversion honours the loaded construct set. HTML implying an unavailable
+  construct degrades to the nearest available representation, falling back to plain text.
+- FR29: Decoration honours the loaded construct set. An unavailable construct is not styled,
+  so its markers appear as ordinary text.
+- FR30: The policy's boundary is documented explicitly: it governs what the editor produces,
+  converts and styles, and cannot prevent a user typing marker characters by hand.
+  Applications needing a hard content guarantee validate server-side.
+
+**Form integration**
+
+- FR31: The component composes `FormControlProps` (label, description, error, errorMessage,
+  required, readonly, disabled), follows the library's error convention of recolouring its own
+  border with the message below, and sets `aria-invalid`. It participates in `CuiForm` on the
+  same terms as every other control: a resolver error for its field renders on it, and
+  `required` renders the indicator and sets `aria-required`. Note that `required` is
+  presentational throughout clean-ui — `CuiForm` validates only through a resolver and has no
+  field registration — so "an empty required editor blocks submit" is not achievable in this
+  package. Native required validation would be a separate clean-ui feature.
+- FR32: `maxLength` counts markdown source characters, since that is what a storage column
+  holds, and displays a counter as `CuiTextarea` does. It never truncates: an edit that would
+  exceed the limit is rejected, and an oversized paste is refused with a message stating the
+  overage. Truncation is excluded deliberately, because cutting at a character boundary can
+  split a link or open a code fence and corrupt the rest of the document.
+
+**Paste and images**
+
+- FR33: Pasting `text/html` converts it to markdown, preserving headings, emphasis, links,
+  lists, code and tables, subject to FR28. Pasting plain text inserts verbatim.
+- FR34: A modifier-key paste inserts the clipboard as plain text without conversion.
+- FR35: In v1, a pasted or dropped image file is refused with a visible, localised message and
+  nothing is inserted. Images are authored by URL through the dialog in FR14.
+
+**Rendering**
+
+- FR36: Rendering markdown to HTML is never required to edit. The core entry contains no
+  markdown-to-HTML renderer and no sanitiser, at any phase.
+- FR37: Components that display rendered markdown accept a `render` adapter so an application
+  can supply the renderer it already uses. The adapter is synchronous in v1 and returns a value
+  produced only by an explicit trust-marking helper, so the type itself states that the caller
+  is asserting the HTML is safe to inject. Widening to allow a promise later is additive;
+  narrowing would not be. A viewer whose adapter throws falls back to escaped source with a
+  developer warning rather than blanking or propagating.
+- FR38: `@itguy614/clean-ui-editor/render` exports a ready-made adapter and a viewer component
+  for applications with no renderer of their own. Nothing in the core entry imports it, and the
+  subpath requires its own build entry to be emitted at all.
+- FR39: The supplied adapter escapes raw HTML by configuring the parser not to emit it, which
+  needs no sanitiser and keeps the subpath free of any DOM dependency so it also runs during
+  server rendering. Allowing raw HTML requires the consumer to supply their own sanitiser
+  function; the library does not bundle one and does not become the security boundary by
+  default.
+- FR40: The viewer applies clean-ui's typography layer itself rather than documenting that
+  consumers should.
+- FR41: The trust boundary is stated in the documentation: the document is untrusted text at
+  all times, enforcement happens at render time, and the server is the only authority. Both
+  `maxLength` (FR32) and the construct policy (FR30) are client-side only.
+- FR42: URL schemes are allowlisted (http, https, mailto, tel, relative) in both the supplied
+  adapter and the FR14 link and image dialog. A `javascript:` URL in link syntax is valid
+  CommonMark and is the most likely real vulnerability in this feature.
+- FR43: The paste converter never emits raw HTML. An element it does not recognise degrades to
+  text, so hostile markup pasted from a web page cannot be laundered into stored content that
+  fires later on a render path with raw HTML enabled.
+- FR44: Rendered widgets, when they arrive in phase 2, are built by constructing DOM from the
+  parse tree, never by producing HTML strings — otherwise FR36's guarantee erodes the first time
+  a widget ships.
+
+### Non-Functional Requirements
+
+- NFR1: The core entry's budget is **130 kB gzip**, measured as the delta a consumer bundle
+  grows by. The prototype spike measured 112.8 kB for CodeMirror, the markdown language, the
+  reveal layer and the autocomplete package the slash menu needs, leaving roughly 17 kB for the
+  toolbar, dialogs and command layer. No module may resolve dependencies through a computed
+  namespace index, the pattern that defeated tree-shaking in clean-ui issue #42.
+- NFR1a: The markdown language is built from `@lezer/markdown` with the GFM extensions
+  directly, not from `@codemirror/lang-markdown`, whose static dependency on the HTML language
+  (and through it JavaScript and CSS) costs **70 kB gzip** for embedded-HTML support this editor
+  does not need. Its list-continuation commands are still imported, which the spike confirmed
+  tree-shakes free of the HTML grammar for 2.3 kB. Any change here is measured, not assumed.
+- NFR2: `vue` and `@itguy614/clean-ui` (`^1.2.0`) are peer dependencies and are never bundled.
+  A caret range, not `>=`, since compatibility with a future major cannot be asserted. clean-ui
+  1.2.0 is the floor because three seams the editor needs do not exist in 1.1.0: an augmentable
+  message-namespace interface (`CuiMessages` is closed today, so NFR5 is not implementable at
+  the type level against 1.1.0), an exported `version` for mismatch detection, and a
+  colour-scheme signal for NFR6. That release is a prerequisite, not a parallel effort.
+- NFR3: Every Phosphor icon the editor renders is registered by the package itself via
+  clean-ui's `registerIcons`, or passed as a component. Since clean-ui 1.1.0 an unregistered
+  name renders a placeholder glyph, so an unregistered toolbar icon would appear broken in
+  consumer applications.
+- NFR4: Server-side rendering must not touch the DOM. On the server the component renders a
+  stable, correctly-sized shell that hydrates without layout shift or hydration mismatch. The
+  shell takes its dimensions from this package's own stylesheet, because CodeMirror's styles are
+  injected at runtime and are therefore absent during server rendering.
+- NFR4a: A `cspNonce` prop is applied when the editor view is constructed, with a fallback to
+  the conventional `csp-nonce` meta tag. CodeMirror injects its styles at runtime, so under a
+  strict `style-src` policy the editor renders unstyled without one — and the nonce cannot be
+  supplied after construction. Both intended consumers are content-security-policy environments
+  (a Laravel CSP middleware, and Tauri's configured policy), so this is a v1 requirement rather
+  than a later accommodation. Documentation states the required policy for consumers who instead
+  permit inline styles.
+- NFR5: All user-visible strings resolve through clean-ui's message catalog under a new
+  namespace, so they are overridable exactly like the rest of the library.
+- NFR6: Appearance derives from clean-ui tokens, honours dark mode and respects the density
+  scale. The package ships no hardcoded colours. This explicitly includes source-mode syntax
+  highlighting: the CodeMirror `HighlightStyle` is built from `--cui-*` tokens rather than using
+  CodeMirror's default palette. Tokens alone are not sufficient for dark mode, because
+  CodeMirror selects its own base-theme rules from a flag fixed when the configuration is built,
+  while clean-ui's dark mode is a class on an arbitrary ancestor that can toggle at runtime and
+  can be scoped to a subtree. That flag is therefore driven from clean-ui's colour-scheme signal
+  (NFR2) through a reconfigurable compartment, or the caret and selection layers stay in light
+  mode with no obvious cause. Extending the repository's contrast audit to cover a second
+  package's tokens is a prerequisite for claiming the audit covers these.
+- NFR7: Accessibility: the editor exposes an accessible name and role; the toolbar is keyboard
+  operable with a single tab stop and arrow-key navigation; controls meet the 24px minimum
+  target size (WCAG 2.5.8); mode changes are announced; the slash menu follows the combobox
+  pattern with full keyboard operation.
+- NFR8: Touch and narrow viewports are first-class: the toolbar scrolls horizontally rather
+  than clipping when it overflows, no control depends on hover, and the reveal model uses the
+  touch granularity in FR8.
+- NFR9: Editing stays responsive on documents of at least 10,000 lines, relying on
+  CodeMirror's viewport rendering rather than rendering the whole document.
+- NFR10: `update:modelValue` emission is throttleable by prop, in combination with FR2.
+- NFR11: Public API is fully typed, including the types a plugin author needs.
+- NFR12: A documented testing contract for consumer applications: stable `data-testid` and
+  `aria-label` hooks on the editor region, toolbar and each command button, plus documentation
+  of which assertions hold under jsdom (value flow, disabled and error states, form
+  validation, button presence) and which require a real browser (marker reveal, paste
+  conversion, slash-menu keyboard operation, toolbar overflow).
+
+## Acceptance Criteria
+
+### Feature Specific
+
+- [ ] `v-model` round-trips a document containing every supported construct plus unknown syntax,
+      an HTML block and a YAML frontmatter block, byte for byte, with no edits made
+- [ ] Typing continuously while `update:modelValue` is throttled and echoed back never moves the
+      cursor or drops characters
+- [ ] Switching mode both ways preserves document, cursor, selection and undo history, verified
+      by undoing across a mode switch
+- [ ] With pointer input, markers hide with the cursor away and reveal with the cursor inside,
+      for each of: emphasis, strong, inline code, heading, link, strikethrough
+- [ ] With touch input, tapping anywhere on a line reveals that line's markers
+- [ ] A screen reader announces the full markdown including markers in `wysiwyg` mode, and the
+      caret traverses exactly the characters announced
+- [ ] IME composition (verified with a CJK input method) completes without interruption or
+      candidate-window displacement in `wysiwyg` mode
+- [ ] Every action in FR11 applies, toggles off, and behaves correctly with an empty selection
+      and a multi-line selection; each is a single undo step
+- [ ] Selecting the words `the docs` and inserting a link yields `[the docs](url)`, not a
+      discarded selection
+- [ ] Enter continues a list item, Enter on an empty item exits, Tab and Shift-Tab indent and
+      outdent, and an ordered list renumbers
+- [ ] The editor inside `CuiForm` shows label, description and a resolver error identically to a
+      sibling `CuiTextarea`, and `required` renders the indicator and sets `aria-required`
+- [ ] With `maxLength` set, typing stops at the limit without truncating, an oversized paste is
+      refused with the overage stated, and no document is left with a split link or open fence
+- [ ] The reference timestamp plugin, registered by a consumer, appears in the toolbar and
+      slash menu and inserts at the cursor with no change to the component's own code
+- [ ] A plugin contributing a raw CodeMirror extension, imported from this package's CodeMirror
+      subpath, takes effect
+- [ ] A plugin declaring `constructs`, a `paste` rule and a `decorations` rule has all three
+      honoured, with no built-in relying on internal access the tier lacks
+- [ ] Failure is contained: a command that throws surfaces through the error hook and leaves the
+      editor usable; an invalid `plugins` value keeps the previous configuration with the
+      document intact; a plugin stamped with an incompatible API version is rejected at
+      registration naming the mismatch
+- [ ] `[click](javascript:alert(1))` is neither produced by the link dialog nor rendered as a
+      live link, and pasted HTML containing a script tag or unrecognised element yields text
+      rather than raw HTML in the stored markdown
+- [ ] With a strict `style-src` and a supplied `cspNonce`, the editor renders styled; without
+      the nonce the failure is documented rather than mysterious
+- [ ] Toggling clean-ui's dark class at runtime updates the editor's caret, selection layer and
+      syntax colours without a remount
+- [ ] A toolbar button renders pressed state from a command's `isActive` while the cursor sits
+      inside that construct
+- [ ] A consumer plugin overriding a built-in command id wins, with a warning naming both
+- [ ] Adding a plugin to the `plugins` array on a mounted editor updates the toolbar without
+      losing document, undo history or cursor
+- [ ] `runCommand` from the exposed API performs the same edit as the toolbar button
+- [ ] Every built-in formatting action is implemented through the public plugin API, provable
+      by the absence of privileged internal command paths
+- [ ] With italic excluded: no button, no `Mod-I`, no slash entry, pasted `<em>` arrives as
+      plain text, and hand-typed asterisks stay unstyled literal characters
+- [ ] Pasting HTML copied from a rendered page produces markdown preserving headings,
+      emphasis, links, lists and a table; plain-text paste is verbatim
+- [ ] A pasted image file is refused with a localised message and nothing is inserted
+- [ ] The core entry's built bundle contains no markdown-to-HTML renderer and no sanitiser,
+      measured on a consumer build; importing `/render` adds them
+- [ ] A viewer driven by a consumer-supplied `render` adapter works with no import from
+      `/render`
+- [ ] The supplied adapter escapes a script tag by default and renders it only when raw HTML is
+      explicitly allowed
+- [ ] Source-mode highlighting uses only `--cui-*` tokens and passes the contrast audit in
+      light and dark mode across themes
+- [ ] Rendering during SSR performs no DOM access and hydrates without warnings
+- [ ] Every string is overridden by supplying a custom message catalog, typed through the
+      augmentation seam
+- [ ] Toolbar is fully keyboard operable with one tab stop, controls measure at least 24px, and
+      at 360px width it scrolls rather than clipping with every action reachable by touch
+- [ ] A 10,000-line document loads and stays responsive while typing
+- [ ] The documented jsdom-safe assertions pass in a jsdom test run
+
+### Verification
+
+Packaging, dependency and CI requirements this feature depends on are specified separately in
+`docs/platform/multi-package-build-and-release.md`, since they apply to any satellite package.
+That document owns the consumer-fixture build, the single-instance enforcement, the bundle
+budget gate, and the test-environment matrix the criteria below assume.
+
+- [ ] All tests pass, including a round-trip suite over a corpus of markdown documents and a
+      unit test asserting the shipped default preset has no internal id or keybinding conflict
+- [ ] Type declarations build with no errors, and a CI check confirms CodeMirror types appear
+      only in the raw-tier declarations, keeping the declarative tier portable
+- [ ] The core bundle stays within its committed budget, verified on a consumer build rather
+      than on this package's own `dist`
+- [ ] Behaviour verified in a real browser, not only jsdom, for: marker reveal on cursor entry,
+      touch-granularity reveal, paste conversion, slash-menu keyboard operation, IME
+      composition, and toolbar overflow
+- [ ] Docs site builds and documents every prop, event, slot, command id and plugin hook
+- [ ] Feature works end-to-end in the docs site against a non-trivial document
+
+## Prototype Evidence
+
+A throwaway spike (since deleted) validated the four assumptions that could have invalidated
+this approach, measured in headless Chrome against a built bundle rather than in jsdom:
+
+- **Reveal.** Markers render zero-width with the caret away and reveal on entry; the construct
+  grows 31 to 63 pixels; the text is unchanged throughout.
+- **Accessibility.** The full markdown, markers included, appears in the browser's accessibility
+  tree — the mechanism FR9 depends on. This is also what proves the hiding technique matters:
+  no DOM-level assertion distinguishes it from an approach that would break screen readers.
+- **Touch.** Line granularity reveals more than construct granularity, and a touch-type pointer
+  event switches modes on its own.
+- **Composition.** An IME composition completes with the text landing intact and the editor
+  reporting composition state throughout, so the decoration layer does not disturb it.
+
+Bundle figures behind NFR1 come from the same spike, as the gzip delta between two otherwise
+identical consumer builds.
+
+Deliberately still unproven, and therefore work the implementation must carry: touch was
+synthesised rather than run on a device, so selection handles and the on-screen keyboard are
+unverified; the composition test drove the browser's IME path directly rather than a real input
+method; and no screen reader has been run, so how the exposed markdown *sounds* is unknown.
+
+## Phasing
+
+**Phase 1.5** — split source-and-preview mode, once the `render` adapter contract exists.
+
+**Phase 2**, in this order:
+
+1. Image upload. Paste or drop a file, an `upload` prop returning a URL, and the interaction
+   already designed for it: insert a localised placeholder immediately, replace exactly that
+   range on success (CodeMirror maps the range as the user keeps typing), remove it and
+   surface an error on failure, and expose an `uploading` state so a form can block submit
+   while a placeholder exists. Likely the first thing the first integration asks for.
+2. Tables as a complete feature: insert action, Tab and Shift-Tab between cells, new row at the
+   last cell, row and column insertion, and the rendered table widget, shipped together.
+3. Remaining rendered widgets: inline images, clickable task checkboxes, syntax-highlighted
+   fences. Each needs its own edit and exit-to-source interaction, which is where this class
+   of editor accumulates defects.
+
+**Phase 3** — a plugin tier for custom markdown syntax (new inline or block constructs with
+their own Lezer grammar), including how unknown syntax degrades for other consumers of the
+document.
+
+**Out of scope** — collaborative or multi-cursor editing, comments, suggestions, revision
+history; footnotes, math and frontmatter as core constructs (candidates for plugins); image
+editing or media library management.
+
+## First Integration
+
+Pulse (`~/code/gohcltech/pulse`) is the first intended consumer once this is built and tested
+here. Two applications would embed it: `app-web` (Laravel with Vue 3.5, Vite) and
+`app-desktop` (Tauri 2 with Vue 3.5). Both already depend on `@itguy614/clean-ui` from the
+registry rather than the workspace, and `app-web` is deliberately not a workspace member, so
+the editor must be consumed as a published package. Neither application authors markdown
+today, so the integration is net-new rather than a migration. Pulse's mobile audit produced
+several of the accessibility and touch requirements above, which is why NFR7, NFR8 and FR8 are
+requirements rather than polish. Pasting a screenshot into a note is the most likely first
+request beyond v1, which is why image upload heads phase 2.
+
+## References
+
+- CodeMirror 6 system guide and reference: https://codemirror.net/docs/
+- Decorations: https://codemirror.net/docs/ref/#view.Decoration
+- Dynamic reconfiguration (`Compartment`): https://codemirror.net/docs/ref/#state.Compartment
+- Lezer markdown parser and GFM extensions: https://github.com/lezer-parser/markdown
+- CommonMark specification: https://spec.commonmark.org/
+- GitHub Flavored Markdown specification: https://github.github.com/gfm/
+- WAI-ARIA Authoring Practices, toolbar and combobox patterns:
+  https://www.w3.org/WAI/ARIA/apg/patterns/
+- WCAG 2.5.8 Target Size (Minimum):
+  https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum
+- clean-ui conventions this package must follow: `CLAUDE.md` in this repository
+- Icon registry behaviour and its rationale: clean-ui issue #42 and `CHANGELOG.md` 1.1.0

--- a/docs/plans/clean-ui-1.2-seams/overview.md
+++ b/docs/plans/clean-ui-1.2-seams/overview.md
@@ -1,0 +1,66 @@
+# clean-ui 1.2.0 Implementation Plan
+
+## Overview
+
+Everything clean-ui must ship before a second published package can exist. Two kinds of work:
+three small API seams the editor cannot fake, and the repository machinery that currently
+assumes exactly one published package.
+
+This release is a **hard prerequisite** for the editor's first publish. The editor's peer range
+resolves against the registry, not the workspace, so 1.2.0 must be on npm before
+`@itguy614/clean-ui-editor` is published (platform requirement P16).
+
+## Specification Source
+
+- `docs/platform/multi-package-build-and-release.md` — requirements P1 to P19
+- `docs/features/markdown-editor.md` — NFR2 (peer floor and why), NFR5 (message namespace),
+  NFR6 (colour-scheme signal)
+
+## Status
+
+| Status      | Count |
+| ----------- | ----- |
+| Complete    | 0     |
+| In Progress | 0     |
+| Not Started | 26    |
+| Blocked     | 0     |
+| Deferred    | 0     |
+
+**Overall Progress:** 0%
+
+## Phases
+
+| #   | Phase                                                        | Status      | Progress |
+| --- | ------------------------------------------------------------ | ----------- | -------- |
+| 01  | [API Seams](./phase-01/)                                     | Not Started | 0/8      |
+| 02  | [Build, Dependencies and Verification](./phase-02/)          | Not Started | 0/9      |
+| 03  | [Release Machinery and Docs Deploy](./phase-03/)             | Not Started | 0/5      |
+| 99  | [Cross-Cutting Concerns](./phase-99/)                        | Not Started | 0/4      |
+
+## Architecture Decisions
+
+- **Message namespaces are opened by declaration merging, not by an index signature.** An index
+  signature would make every message key `any`-ish and lose the type safety the catalog exists
+  for. An empty `CuiMessageNamespaces` interface that `CuiMessages` extends lets a satellite
+  package augment it and keep full checking.
+- **The colour-scheme signal observes an ancestor, not the document.** clean-ui's dark mode is a
+  class on any element and may be scoped to a subtree, so a global boolean would be wrong for
+  scoped usage. The composable resolves per call site.
+- **Dependencies are externalized by rule, never by a maintained list.** The current
+  four-specifier literal works only because clean-ui has two dependencies; it silently inlines
+  anything a future package forgets to add.
+- **Verification happens in a consumer build.** Every guarantee this library advertises has been
+  broken at least once (#42, #62) and neither was caught by this repository's own builds, which
+  alias the library to source.
+- **Versions stay lockstep.** Chosen deliberately over independent versioning: the root
+  `VERSION`, root `CHANGELOG.md` and `vX.Y.Z` tags all survive, at the cost of version churn on
+  packages that did not change. A changed-files guard stops that churn from republishing
+  identical artifacts.
+
+## Dependencies
+
+- No external blockers. All work is inside this repository.
+- Phase 03 depends on Phase 02's build changes being in place, since the publish matrix packs
+  what the build produces.
+- The editor plan (`docs/plans/markdown-editor-phase-1/`) depends on Phase 01 landing, and on
+  Phase 02 and 03 before its own publish.

--- a/docs/plans/clean-ui-1.2-seams/overview.md
+++ b/docs/plans/clean-ui-1.2-seams/overview.md
@@ -22,7 +22,7 @@ resolves against the registry, not the workspace, so 1.2.0 must be on npm before
 | ----------- | ----- |
 | Complete    | 0     |
 | In Progress | 0     |
-| Not Started | 26    |
+| Not Started | 25    |
 | Blocked     | 0     |
 | Deferred    | 0     |
 
@@ -35,7 +35,7 @@ resolves against the registry, not the workspace, so 1.2.0 must be on npm before
 | 01  | [API Seams](./phase-01/)                                     | Not Started | 0/8      |
 | 02  | [Build, Dependencies and Verification](./phase-02/)          | Not Started | 0/9      |
 | 03  | [Release Machinery and Docs Deploy](./phase-03/)             | Not Started | 0/5      |
-| 99  | [Cross-Cutting Concerns](./phase-99/)                        | Not Started | 0/4      |
+| 99  | [Cross-Cutting Concerns](./phase-99/)                        | Not Started | 0/3      |
 
 ## Architecture Decisions
 

--- a/docs/plans/clean-ui-1.2-seams/phase-01/phase-01-journal.md
+++ b/docs/plans/clean-ui-1.2-seams/phase-01/phase-01-journal.md
@@ -1,0 +1,16 @@
+# Phase 01 Journal: API Seams
+
+Progress, decisions and notes logged as tasks are addressed. Entries are appended by whoever works
+a task — the tasks file tracks status, this file records why things happened.
+
+## Log
+
+_No entries yet._
+
+<!-- Template:
+### YYYY-MM-DD - Task N.G.T: Title
+**Agent:** {agent}  **Status:** {Started|Completed|Blocked}
+**Work Done:**
+**Decisions Made:**
+**Notes:**
+-->

--- a/docs/plans/clean-ui-1.2-seams/phase-01/phase-01-tasks.md
+++ b/docs/plans/clean-ui-1.2-seams/phase-01/phase-01-tasks.md
@@ -1,0 +1,204 @@
+# Phase 01: API Seams
+
+## Overview
+
+Three additions to clean-ui's public API that a satellite package cannot work around, plus the
+runtime guard that makes a duplicated clean-ui fail loudly instead of silently. All additive, so
+1.2.0 is a minor.
+
+## Status
+
+| Status      | Count |
+| ----------- | ----- |
+| Complete    | 0     |
+| In Progress | 0     |
+| Not Started | 8     |
+| Blocked     | 0     |
+| Deferred    | 0     |
+
+**Progress:** 0/8 tasks complete
+
+## Agent Assignments
+
+| Agent                                  | Focus Area                          | Tasks         |
+| -------------------------------------- | ----------------------------------- | ------------- |
+| web-developer-tools:frontend-developer | Composables, types, message catalog | 1.1.1 – 1.3.2 |
+| developer-tools:testing-specialist     | Unit tests for each seam            | 1.1.3, 1.2.3  |
+
+## Tasks
+
+### Group 1.1: Message namespace augmentation
+
+#### Task 1.1.1: Open `CuiMessages` for augmentation
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | low |
+| Dependencies | None |
+
+**Description:**
+`CuiMessages` in `packages/clean-ui/src/messages.ts` is a closed interface, and it is re-exported
+from the barrel, so TypeScript module augmentation cannot merge into it from another package.
+Introduce an empty `CuiMessageNamespaces` interface that `CuiMessages` extends, so a satellite
+package can declare its own namespace and keep full type checking. `mergeMessages` already
+passes unknown keys through at runtime, so this is a type-level change only.
+
+**Acceptance Criteria:**
+- [ ] A separate package can augment `CuiMessageNamespaces` and have its namespace type-check
+      inside `CuiConfigProvider`'s messages prop
+- [ ] Existing message keys keep their exact types; nothing becomes loosely typed
+- [ ] `defaultMessages` and `mergeMessages` behaviour is unchanged
+
+---
+
+#### Task 1.1.2: Document the augmentation pattern
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | low |
+| Dependencies | 1.1.1 |
+
+**Description:**
+Add the satellite-package recipe to the Localization docs page: the `declare module` block, where
+to put it, and how the namespace then appears in the catalog. This is the page consumers already
+use for message overrides.
+
+**Acceptance Criteria:**
+- [ ] Localization page shows a complete, copyable augmentation example
+- [ ] The existing namespace list mentions that satellite packages may add their own
+
+---
+
+#### Task 1.1.3: Type-level test for the seam
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | testing-specialist |
+| Complexity | medium |
+| Dependencies | 1.1.1 |
+
+**Description:**
+A compile-time test asserting the augmentation works and that a wrong-shaped namespace is
+rejected. Runtime tests cannot catch a regression here, since the failure mode is purely
+type-level.
+
+**Acceptance Criteria:**
+- [ ] A fixture augmenting the interface type-checks under `vue-tsc`
+- [ ] A deliberately wrong namespace shape fails the type check
+- [ ] The check runs as part of the existing type-check step
+
+---
+
+### Group 1.2: Colour-scheme signal
+
+#### Task 1.2.1: `useColorScheme` composable
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | None |
+
+**Description:**
+clean-ui exposes no dark-mode state: `useTheme` handles presets only, and dark mode is a `.dark`
+class on an arbitrary ancestor that can toggle at runtime and can be scoped to a subtree. Add a
+composable returning a reactive `isDark` resolved from the nearest ancestor of the calling
+component, observing class changes. Consumers such as CodeMirror need this because their own dark
+flag is fixed when configuration is built, not read from the cascade.
+
+**Acceptance Criteria:**
+- [ ] Reports the scheme for the calling component's own ancestor chain, not the document
+- [ ] Reacts to a class toggled on any ancestor, including a scoped subtree
+- [ ] SSR-safe: no DOM access during server rendering, correct after hydration
+- [ ] Observers are disconnected on unmount
+
+---
+
+#### Task 1.2.2: Adopt it in the library where dark mode is inferred
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | low |
+| Dependencies | 1.2.1 |
+
+**Description:**
+Audit components that need to know the scheme in JavaScript rather than CSS, and route them
+through the new composable so there is one implementation. Components that resolve dark mode
+purely in CSS are left alone — this is not a refactor of the token system.
+
+**Acceptance Criteria:**
+- [ ] No component hand-rolls a `.dark` class observer
+- [ ] No visual change in either mode, verified in the docs site
+
+---
+
+#### Task 1.2.3: Tests for scoped and toggled dark mode
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | testing-specialist |
+| Complexity | medium |
+| Dependencies | 1.2.1 |
+
+**Description:**
+Cover the cases that make a global boolean wrong: a scoped subtree, a toggle after mount, and
+nested scopes disagreeing.
+
+**Acceptance Criteria:**
+- [ ] Two components in differently-scoped subtrees report different values
+- [ ] Toggling a class after mount updates subscribers
+- [ ] Unmounting removes the observer
+
+---
+
+### Group 1.3: Version export and duplicate detection
+
+#### Task 1.3.1: Export `version`
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | low |
+| Dependencies | None |
+
+**Description:**
+The package exports no version, so a satellite cannot detect a mismatch against its peer range.
+Export a `version` constant, sourced from `package.json` at build time so it cannot drift.
+
+**Acceptance Criteria:**
+- [ ] `version` is exported from the barrel and matches `package.json` exactly
+- [ ] The value is inlined at build time, not read from the filesystem at runtime
+- [ ] A test fails if the two disagree
+
+---
+
+#### Task 1.3.2: Warn on a duplicated clean-ui instance
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | 1.3.1 |
+
+**Description:**
+Every seam a satellite uses is a module-scope singleton — injection keys, the icon registry,
+density state. Two copies in a consumer tree make form binding, messages and icons fail
+*silently*: no error, just a missing label and a placeholder glyph. Stamp identity on a versioned
+global on first use and emit a one-time developer warning when a second, different instance
+appears, naming the versions and the likely cause.
+
+**Acceptance Criteria:**
+- [ ] A simulated second instance produces one warning naming both versions
+- [ ] The warning suggests the concrete fix (dedupe or a matching peer range)
+- [ ] Single-instance usage is silent, and the check costs nothing measurable

--- a/docs/plans/clean-ui-1.2-seams/phase-02/phase-02-journal.md
+++ b/docs/plans/clean-ui-1.2-seams/phase-02/phase-02-journal.md
@@ -1,0 +1,16 @@
+# Phase 02 Journal: Build, Dependencies and Verification
+
+Progress, decisions and notes logged as tasks are addressed. Entries are appended by whoever works
+a task — the tasks file tracks status, this file records why things happened.
+
+## Log
+
+_No entries yet._
+
+<!-- Template:
+### YYYY-MM-DD - Task N.G.T: Title
+**Agent:** {agent}  **Status:** {Started|Completed|Blocked}
+**Work Done:**
+**Decisions Made:**
+**Notes:**
+-->

--- a/docs/plans/clean-ui-1.2-seams/phase-02/phase-02-tasks.md
+++ b/docs/plans/clean-ui-1.2-seams/phase-02/phase-02-tasks.md
@@ -1,0 +1,227 @@
+# Phase 02: Build, Dependencies and Verification
+
+## Overview
+
+Make the build tolerate a package with a real dependency graph, and make the guarantees this
+library advertises verifiable in a consumer build rather than asserted. Every requirement here
+exists because something in this class already broke once: #42 shipped an icon barrel that
+defeated tree-shaking, #62 shipped Tailwind utilities that overrode consumers' CSS. Neither was
+caught here, because the docs app aliases the library to source.
+
+## Status
+
+| Status      | Count |
+| ----------- | ----- |
+| Complete    | 0     |
+| In Progress | 0     |
+| Not Started | 9     |
+| Blocked     | 0     |
+| Deferred    | 0     |
+
+**Progress:** 0/9 tasks complete
+
+## Agent Assignments
+
+| Agent                                  | Focus Area                              | Tasks         |
+| -------------------------------------- | --------------------------------------- | ------------- |
+| web-developer-tools:full-stack-developer | Build config, CI workflows, fixture app | 2.1.1 – 2.3.3 |
+| developer-tools:testing-specialist     | Test environment projects               | 2.3.1, 2.3.2  |
+
+## Tasks
+
+### Group 2.1: Dependency policy
+
+#### Task 2.1.1: Externalize by rule
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | full-stack-developer |
+| Complexity | medium |
+| Dependencies | None |
+
+**Description:**
+`packages/clean-ui/vite.config.ts` externalizes a hand-written list of four specifiers. Replace it
+with a predicate derived from `dependencies` and `peerDependencies`, matched by prefix so subpath
+imports are covered. A list works for two dependencies and silently inlines the third.
+
+**Acceptance Criteria:**
+- [ ] Adding a dependency requires no change to the build config
+- [ ] Subpath imports of an external package are also externalized
+- [ ] The built output is byte-comparable to the current one for the existing dependency set
+
+---
+
+#### Task 2.1.2: Assert no undeclared imports in `dist`
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | full-stack-developer |
+| Complexity | medium |
+| Dependencies | 2.1.1 |
+
+**Description:**
+A check over the built output asserting every bare import specifier is either relative or declared
+in that package's `package.json`. This closes the whole class rather than the cases someone
+remembered to list.
+
+**Acceptance Criteria:**
+- [ ] Fails with a clear message when a dependency is imported but undeclared
+- [ ] Runs in CI for every publishable package
+- [ ] Passes on the current `dist`
+
+---
+
+#### Task 2.1.3: Audit `sideEffects`
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | full-stack-developer |
+| Complexity | low |
+| Dependencies | None |
+
+**Description:**
+`sideEffects` currently lists CSS plus the lazy icon module. Confirm the declaration is accurate
+for every emitted module and document the rule for satellites: any module whose import must not be
+dropped needs listing, which is how the opt-in lazy icon entry works today.
+
+**Acceptance Criteria:**
+- [ ] Declaration verified against every emitted module
+- [ ] The rule is documented alongside the platform requirements
+
+---
+
+### Group 2.2: Consumer fixture verification
+
+#### Task 2.2.1: Fixture app and packing harness
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | full-stack-developer |
+| Complexity | high |
+| Dependencies | 2.1.1 |
+
+**Description:**
+A CI job that packs every publishable package with `pnpm pack`, installs the tarballs into a
+throwaway Vite and Vue app using **npm** rather than the pnpm workspace — which is how the real
+consumers install — and builds it. This is the only place the exports map, peer resolution and
+published file list are exercised at all.
+
+**Acceptance Criteria:**
+- [ ] Job packs, installs with npm, and builds without workspace linkage
+- [ ] Failure messages identify which package and which assertion failed
+- [ ] Runs on pull requests, not only on release
+
+---
+
+#### Task 2.2.2: Guarantee assertions
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | full-stack-developer |
+| Complexity | medium |
+| Dependencies | 2.2.1 |
+
+**Description:**
+Express the package guarantees as assertions over the fixture's build output: no icon barrel
+present (the #42 regression), no CSS utilities layer (the #62 regression), exactly one copy of
+each single-instance dependency, and — once the editor exists — no renderer in the core entry
+while the render subpath adds one.
+
+**Acceptance Criteria:**
+- [ ] Each assertion fails when its regression is deliberately reintroduced
+- [ ] Assertions are named so a failure reads as a broken promise, not a mystery
+- [ ] Extensible: adding a package adds its assertions without restructuring the job
+
+---
+
+#### Task 2.2.3: Committed size budgets
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | full-stack-developer |
+| Complexity | medium |
+| Dependencies | 2.2.1 |
+
+**Description:**
+Budgets in a committed file, measured as the gzip delta a consumer bundle grows by, with CI
+failing on regression. `scripts/postbuild.mjs` measures this package's own `dist`, which is not
+the metric any requirement actually cares about.
+
+**Acceptance Criteria:**
+- [ ] Budget file records a number per package entry with the date measured
+- [ ] A deliberate regression fails CI with both numbers in the message
+- [ ] The delta methodology is documented so future measurements are comparable
+
+---
+
+### Group 2.3: Test environments
+
+#### Task 2.3.1: Node project for server-rendering assertions
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | testing-specialist |
+| Complexity | medium |
+| Dependencies | None |
+
+**Description:**
+"Renders without DOM access and hydrates cleanly" cannot be asserted from a jsdom environment,
+where a DOM always exists. Add a second vitest project with the node environment that renders
+components through the server renderer.
+
+**Acceptance Criteria:**
+- [ ] A component touching the DOM during setup fails this project
+- [ ] Existing jsdom tests are unaffected
+- [ ] Both projects run in the standard test command
+
+---
+
+#### Task 2.3.2: Browser runner for layout and input behaviour
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | testing-specialist |
+| Complexity | high |
+| Dependencies | None |
+
+**Description:**
+A real-browser runner for behaviour that depends on layout, selection or input method. Several
+existing verifications in this repository have been done by hand-driving Chrome; this makes that
+capability standing rather than ad hoc. Non-blocking in CI initially is acceptable; absent is not,
+because these are the behaviours that regress silently.
+
+**Acceptance Criteria:**
+- [ ] Runner executes against a built app in CI
+- [ ] At least one existing layout-dependent behaviour is covered as a proving case
+- [ ] Documented how to run it locally and how to triage a failure
+
+---
+
+#### Task 2.3.3: Shared alias module and jsdom polyfills
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | full-stack-developer |
+| Complexity | low |
+| Dependencies | None |
+
+**Description:**
+Two things that will bite the moment a second docs app exists. Extract the alias list mapping
+package names to workspace source into one shared module used by every docs app and test setup, so
+two apps cannot disagree and load two copies of clean-ui. Separately, add the `Range` measurement
+polyfills a DOM-dependent editor needs to mount under jsdom at all — without them the failure
+looks like "this cannot be tested" rather than a missing stub.
+
+**Acceptance Criteria:**
+- [ ] One module owns resolution policy; docs apps and test setups import it
+- [ ] A DOM-measuring component mounts in the jsdom project
+- [ ] `CONTRIBUTING.md`'s stale claim that docs consume the built library is corrected

--- a/docs/plans/clean-ui-1.2-seams/phase-03/phase-03-journal.md
+++ b/docs/plans/clean-ui-1.2-seams/phase-03/phase-03-journal.md
@@ -1,0 +1,16 @@
+# Phase 03 Journal: Release Machinery and Docs Deploy
+
+Progress, decisions and notes logged as tasks are addressed. Entries are appended by whoever works
+a task — the tasks file tracks status, this file records why things happened.
+
+## Log
+
+_No entries yet._
+
+<!-- Template:
+### YYYY-MM-DD - Task N.G.T: Title
+**Agent:** {agent}  **Status:** {Started|Completed|Blocked}
+**Work Done:**
+**Decisions Made:**
+**Notes:**
+-->

--- a/docs/plans/clean-ui-1.2-seams/phase-03/phase-03-tasks.md
+++ b/docs/plans/clean-ui-1.2-seams/phase-03/phase-03-tasks.md
@@ -1,0 +1,141 @@
+# Phase 03: Release Machinery and Docs Deploy
+
+## Overview
+
+The publish and deploy workflows are single-package by construction. Under lockstep versioning the
+root `VERSION`, root `CHANGELOG.md` and `vX.Y.Z` tags all survive, so this phase is narrower than
+independent versioning would have required — but the publish job still has to become a matrix, and
+GitHub Pages still hosts one site per repository.
+
+Do this before the editor package exists. Discovering it during the editor's first release turns a
+planned change into an emergency.
+
+## Status
+
+| Status      | Count |
+| ----------- | ----- |
+| Complete    | 0     |
+| In Progress | 0     |
+| Not Started | 5     |
+| Blocked     | 0     |
+| Deferred    | 0     |
+
+**Progress:** 0/5 tasks complete
+
+## Agent Assignments
+
+| Agent                                    | Focus Area                  | Tasks         |
+| ---------------------------------------- | --------------------------- | ------------- |
+| web-developer-tools:full-stack-developer | Workflows, release tooling  | 3.1.1 – 3.2.2 |
+
+## Tasks
+
+### Group 3.1: Publish and CI
+
+#### Task 3.1.1: Publish as a matrix over packages
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | full-stack-developer |
+| Complexity | medium |
+| Dependencies | None |
+
+**Description:**
+`publish-npm.yml` hardcodes `working-directory: packages/clean-ui` and a single version check.
+Turn it into a matrix over publishable packages, keeping the `npm view` idempotency check that
+already works — it makes re-runs and non-bumping pushes safe.
+
+**Acceptance Criteria:**
+- [ ] Publishing clean-ui alone still works exactly as it does today
+- [ ] Adding a package to the matrix requires no other workflow change
+- [ ] A re-run of an already-published version is a no-op
+
+---
+
+#### Task 3.1.2: Changed-files guard
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | full-stack-developer |
+| Complexity | medium |
+| Dependencies | 3.1.1 |
+
+**Description:**
+Under lockstep, a clean-ui-only patch moves every package's version, so the `npm view` check sees
+a genuinely new version and would republish a byte-identical package. Skip a package whose files
+have not changed since the previous release tag.
+
+**Acceptance Criteria:**
+- [ ] A release touching only clean-ui publishes only clean-ui
+- [ ] A release touching both publishes both
+- [ ] The skip is logged so a release reader can see it was intentional
+
+---
+
+#### Task 3.1.3: CI across the workspace
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | full-stack-developer |
+| Complexity | medium |
+| Dependencies | None |
+
+**Description:**
+`ci.yml` filters to `@itguy614/clean-ui` in three places and type-checks one docs app, so a new
+package would be invisible on day one. Move to workspace-recursive, topological build and test,
+keeping the Node version matrix. A green pipeline that does not look at the new package is worse
+than no pipeline.
+
+**Acceptance Criteria:**
+- [ ] Every workspace package builds and tests on every supported Node version
+- [ ] Build order respects workspace dependencies
+- [ ] The fixture job from Phase 02 runs alongside
+
+---
+
+### Group 3.2: Documentation deploy and conventions
+
+#### Task 3.2.1: Compose multiple docs sites into one Pages artifact
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | full-stack-developer |
+| Complexity | medium |
+| Dependencies | None |
+
+**Description:**
+`deploy-docs.yml` uploads one app's `dist` as the entire artifact with a single `404.html`. Pages
+hosts one site per repository, so multiple docs apps must be built with their own base paths into
+subdirectories of a composed artifact, each with its own `404.html`, all rebuilt on every deploy.
+
+**Acceptance Criteria:**
+- [ ] The existing site keeps its current URL
+- [ ] A second app is reachable at its own base path with working deep links
+- [ ] Both are rebuilt on every deploy, so neither can go stale
+
+---
+
+#### Task 3.2.2: Record the release and changelog conventions
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | full-stack-developer |
+| Complexity | low |
+| Dependencies | 3.1.1, 3.1.2 |
+
+**Description:**
+Write down what lockstep means in practice, because the next release will be run by someone
+reading the docs rather than this plan: one shared version, changelog entries naming the package
+when it is not clean-ui, a new package joining at the current shared version rather than 1.0.0,
+and the rule that a satellite release depending on a new clean-ui seam must not reach `master`
+before the clean-ui release providing it.
+
+**Acceptance Criteria:**
+- [ ] `CONTRIBUTING.md` describes the release process accurately
+- [ ] The ordering rule for coupled releases is stated explicitly
+- [ ] The `/make-release` workflow's behaviour matches what is documented

--- a/docs/plans/clean-ui-1.2-seams/phase-99/phase-99-journal.md
+++ b/docs/plans/clean-ui-1.2-seams/phase-99/phase-99-journal.md
@@ -1,0 +1,16 @@
+# Phase 99 Journal: Cross-Cutting Concerns
+
+Progress, decisions and notes logged as tasks are addressed. Entries are appended by whoever works
+a task — the tasks file tracks status, this file records why things happened.
+
+## Log
+
+_No entries yet._
+
+<!-- Template:
+### YYYY-MM-DD - Task N.G.T: Title
+**Agent:** {agent}  **Status:** {Started|Completed|Blocked}
+**Work Done:**
+**Decisions Made:**
+**Notes:**
+-->

--- a/docs/plans/clean-ui-1.2-seams/phase-99/phase-99-tasks.md
+++ b/docs/plans/clean-ui-1.2-seams/phase-99/phase-99-tasks.md
@@ -11,45 +11,31 @@ carried silently into a two-package world.
 | ----------- | ----- |
 | Complete    | 0     |
 | In Progress | 0     |
-| Not Started | 4     |
+| Not Started | 3     |
 | Blocked     | 0     |
 | Deferred    | 0     |
 
-**Progress:** 0/4 tasks complete
+**Progress:** 0/3 tasks complete
 
 ## Agent Assignments
 
 | Agent                                    | Focus Area                    | Tasks           |
 | ---------------------------------------- | ----------------------------- | --------------- |
-| web-developer-tools:full-stack-developer | Tooling, audit scripts        | 99.1.1, 99.1.2  |
-| developer-tools:documentation-expert     | Convention documentation      | 99.1.3, 99.1.4  |
+| web-developer-tools:full-stack-developer | Tooling, audit scripts        | 99.1.1          |
+| developer-tools:documentation-expert     | Convention documentation      | 99.1.2, 99.1.3  |
+
+## Decisions Already Taken
+
+- **No linter.** The repository has no eslint, prettier or biome configuration, and the root `lint`
+  script matches nothing. Rather than introduce one, the acceptance criteria that claimed "linting
+  passes" were struck from the specifications; `vue-tsc` remains the automated code gate. Recorded
+  here because the absence is deliberate, not an oversight for someone to helpfully fix.
 
 ## Tasks
 
 ### Group 99.1: Repository hygiene
 
-#### Task 99.1.1: Decide the linter question
-
-| Field | Value |
-|-------|-------|
-| Status | `[ ]` Not Started |
-| Assigned | full-stack-developer |
-| Complexity | medium |
-| Dependencies | None |
-
-**Description:**
-There is no linter in this repository — no eslint, prettier or biome configuration — and the root
-`lint` script matches no package script. Any acceptance criterion claiming "linting passes" is
-currently false, and this spec set contains such claims. Either add a flat config or remove the
-claims; do not leave both in place. Worth resolving before a second package doubles the surface.
-
-**Acceptance Criteria:**
-- [ ] Either a linter runs in CI across the workspace, or no document claims one does
-- [ ] If added, it passes on the existing code without a mass reformat in the same change
-
----
-
-#### Task 99.1.2: Extend the contrast audit beyond one package
+#### Task 99.1.1: Extend the contrast audit beyond one package
 
 | Field | Value |
 |-------|-------|
@@ -71,7 +57,7 @@ from configuration.
 
 ---
 
-#### Task 99.1.3: Record the global-install exception in CLAUDE.md
+#### Task 99.1.2: Record the global-install exception in CLAUDE.md
 
 | Field | Value |
 |-------|-------|
@@ -93,7 +79,7 @@ follows the rule and undoes the reason the package was split.
 
 ---
 
-#### Task 99.1.4: Reconcile the docs with reality
+#### Task 99.1.3: Reconcile the docs with reality
 
 | Field | Value |
 |-------|-------|

--- a/docs/plans/clean-ui-1.2-seams/phase-99/phase-99-tasks.md
+++ b/docs/plans/clean-ui-1.2-seams/phase-99/phase-99-tasks.md
@@ -1,0 +1,112 @@
+# Phase 99: Cross-Cutting Concerns
+
+## Overview
+
+Repository-wide items surfaced by the reviews that are not blocking the seams but should not be
+carried silently into a two-package world.
+
+## Status
+
+| Status      | Count |
+| ----------- | ----- |
+| Complete    | 0     |
+| In Progress | 0     |
+| Not Started | 4     |
+| Blocked     | 0     |
+| Deferred    | 0     |
+
+**Progress:** 0/4 tasks complete
+
+## Agent Assignments
+
+| Agent                                    | Focus Area                    | Tasks           |
+| ---------------------------------------- | ----------------------------- | --------------- |
+| web-developer-tools:full-stack-developer | Tooling, audit scripts        | 99.1.1, 99.1.2  |
+| developer-tools:documentation-expert     | Convention documentation      | 99.1.3, 99.1.4  |
+
+## Tasks
+
+### Group 99.1: Repository hygiene
+
+#### Task 99.1.1: Decide the linter question
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | full-stack-developer |
+| Complexity | medium |
+| Dependencies | None |
+
+**Description:**
+There is no linter in this repository — no eslint, prettier or biome configuration — and the root
+`lint` script matches no package script. Any acceptance criterion claiming "linting passes" is
+currently false, and this spec set contains such claims. Either add a flat config or remove the
+claims; do not leave both in place. Worth resolving before a second package doubles the surface.
+
+**Acceptance Criteria:**
+- [ ] Either a linter runs in CI across the workspace, or no document claims one does
+- [ ] If added, it passes on the existing code without a mass reformat in the same change
+
+---
+
+#### Task 99.1.2: Extend the contrast audit beyond one package
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | full-stack-developer |
+| Complexity | medium |
+| Dependencies | None |
+
+**Description:**
+`scripts/check-contrast.mjs` reads clean-ui's `theme.css` with a hardcoded token pair list, so it
+cannot see a second package's tokens. The editor's syntax-highlighting requirement claims coverage
+by "the same contrast audit", which depends on this. Generalise the script to take token sources
+from configuration.
+
+**Acceptance Criteria:**
+- [ ] The script audits token pairs from more than one package
+- [ ] Existing clean-ui coverage is unchanged
+- [ ] A failing pair in either package fails the audit with its source named
+
+---
+
+#### Task 99.1.3: Record the global-install exception in CLAUDE.md
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | documentation-expert |
+| Complexity | low |
+| Dependencies | None |
+
+**Description:**
+The component checklist tells contributors to register components in the plugin's global
+`app.component()` install. A satellite package with a heavy dependency graph must not do that: a
+global install puts its whole dependency tree in every consumer's main bundle and defeats
+route-level code splitting. Record the exception where the rule lives, or the next contributor
+follows the rule and undoes the reason the package was split.
+
+**Acceptance Criteria:**
+- [ ] The checklist states the exception and why
+- [ ] Satellite packages are directed to named imports with an async-component example
+
+---
+
+#### Task 99.1.4: Reconcile the docs with reality
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | documentation-expert |
+| Complexity | low |
+| Dependencies | 3.2.2 |
+
+**Description:**
+Small factual drift found while reviewing: `CONTRIBUTING.md` says the docs site consumes the built
+library when it aliases to source, and the release instructions predate the matrix. Fix both, and
+sanity-check the rest of the contributor documentation against the current setup while in there.
+
+**Acceptance Criteria:**
+- [ ] No contributor-facing document describes a setup that no longer exists
+- [ ] The build, test and release commands in the docs actually work as written

--- a/docs/plans/markdown-editor-phase-1/overview.md
+++ b/docs/plans/markdown-editor-phase-1/overview.md
@@ -1,0 +1,81 @@
+# Markdown Editor Phase 1 Implementation Plan
+
+## Overview
+
+The v1 editor: `@itguy614/clean-ui-editor`, a markdown editor where markdown text is the document,
+CodeMirror 6 provides the buffer, and syntax markers hide until the caret enters the construct.
+Ships with a plugin API expressive enough that its own built-in actions use it, an injectable
+render adapter so no renderer lands in the core bundle, and a construct policy that makes
+excluding a plugin mean the construct cannot enter the document.
+
+Out of scope for this plan, in the order they follow: image upload, tables as a complete feature,
+rendered widgets, split preview, and a plugin tier for custom markdown syntax.
+
+## Specification Source
+
+- `docs/features/markdown-editor.md` — 44 functional and 12 non-functional requirements
+- `docs/platform/multi-package-build-and-release.md` — packaging and verification requirements
+
+## Status
+
+| Status      | Count |
+| ----------- | ----- |
+| Complete    | 0     |
+| In Progress | 0     |
+| Not Started | 44    |
+| Blocked     | 0     |
+| Deferred    | 0     |
+
+**Overall Progress:** 0%
+
+## Phases
+
+| #   | Phase                                                    | Status      | Progress |
+| --- | -------------------------------------------------------- | ----------- | -------- |
+| 01  | [Package Scaffold and Editor Foundation](./phase-01/)    | Not Started | 0/7      |
+| 02  | [Reveal Layer and Theming](./phase-02/)                  | Not Started | 0/7      |
+| 03  | [Plugin System](./phase-03/)                             | Not Started | 0/8      |
+| 04  | [Built-in Plugins, Slash Menu and Paste](./phase-04/)    | Not Started | 0/8      |
+| 05  | [Form Integration, Limits and Messages](./phase-05/)     | Not Started | 0/5      |
+| 06  | [Render Subpath](./phase-06/)                            | Not Started | 0/4      |
+| 07  | [Documentation Site](./phase-07/)                        | Not Started | 0/5      |
+
+## Architecture Decisions
+
+Settled during specification; recorded here because a task list read on its own invites
+re-litigating them.
+
+- **Markdown is the document.** No rich-text model, so no conversion and no round-trip drift.
+  Source mode is the same buffer with decorations off.
+- **The markdown language is built from `@lezer/markdown` with GFM**, not from
+  `@codemirror/lang-markdown`, whose static dependency on the HTML language costs 70 kB gzip for
+  embedded-HTML support this editor does not use. Its list-continuation commands are imported
+  separately, which measurably tree-shakes free of that graph.
+- **Hiding uses a mark decoration, never `Decoration.replace()`.** Replace removes characters from
+  the DOM and so from the accessibility tree, which the spec forbids.
+- **Reveal granularity follows input type:** construct-level for a pointer, whole-line for touch.
+- **Commands are synchronous and return a boolean.** Async work goes through seams the editor owns,
+  so position validity and undo grouping are solved once rather than per plugin author.
+- **The declarative plugin tier must express everything the built-ins need.** If a built-in needs
+  privileged access, the tier is wrong — that is a design signal, not an implementation shortcut.
+- **CodeMirror is a runtime dependency, re-exported through a subpath.** Plugin authors get
+  CodeMirror from this package so a single instance is the default rather than something consumers
+  must arrange.
+
+## Dependencies
+
+- **Blocking:** clean-ui 1.2.0 must be published before this package is
+  (`docs/plans/clean-ui-1.2-seams/`). Phase 01 can begin against the workspace link, but the
+  message namespace (Phase 05) and dark-mode signal (Phase 02) need the seams to exist.
+- **Blocking for publish:** the platform plan's Phase 02 and 03 — the fixture verification and the
+  publish matrix.
+- Phases 02, 03 and 06 are independent of each other once Phase 01 lands and could run in
+  parallel; Phase 04 depends on Phase 03, and Phase 05 on Phase 01.
+
+## Verification Debt Carried From the Spike
+
+The prototype validated reveal, accessibility-tree exposure, touch granularity and IME composition
+in headless Chrome. It did **not** prove: touch behaviour on a physical device (selection handles,
+on-screen keyboard), composition through a real input method, or how the exposed markdown sounds in
+a screen reader. Those are tasks in Phase 99 of the platform plan's browser runner and in this
+plan's Phase 02, not assumptions.

--- a/docs/plans/markdown-editor-phase-1/phase-01/phase-01-journal.md
+++ b/docs/plans/markdown-editor-phase-1/phase-01/phase-01-journal.md
@@ -1,0 +1,16 @@
+# Phase 01 Journal: Package Scaffold and Editor Foundation
+
+Progress, decisions and notes logged as tasks are addressed. Entries are appended by whoever works
+a task — the tasks file tracks status, this file records why things happened.
+
+## Log
+
+_No entries yet._
+
+<!-- Template:
+### YYYY-MM-DD - Task N.G.T: Title
+**Agent:** {agent}  **Status:** {Started|Completed|Blocked}
+**Work Done:**
+**Decisions Made:**
+**Notes:**
+-->

--- a/docs/plans/markdown-editor-phase-1/phase-01/phase-01-tasks.md
+++ b/docs/plans/markdown-editor-phase-1/phase-01/phase-01-tasks.md
@@ -1,0 +1,192 @@
+# Phase 01: Package Scaffold and Editor Foundation
+
+## Overview
+
+Create the package with its exports, entries and dependency policy correct from the first commit,
+and get a CodeMirror editor mounting inside a Vue component with the value contract and mode switch
+working. The packaging details here are the ones that are expensive to retrofit: subpath entries,
+the CodeMirror re-export, the CSP nonce, and the SSR shell.
+
+## Status
+
+| Status      | Count |
+| ----------- | ----- |
+| Complete    | 0     |
+| In Progress | 0     |
+| Not Started | 7     |
+| Blocked     | 0     |
+| Deferred    | 0     |
+
+**Progress:** 0/7 tasks complete
+
+## Agent Assignments
+
+| Agent                                    | Focus Area                        | Tasks         |
+| ---------------------------------------- | --------------------------------- | ------------- |
+| web-developer-tools:full-stack-developer | Package setup, build, exports     | 1.1.1 – 1.1.3 |
+| web-developer-tools:frontend-developer   | Component, value contract, modes  | 1.2.1 – 1.2.4 |
+
+## Tasks
+
+### Group 1.1: Package and build
+
+#### Task 1.1.1: Scaffold the package
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | full-stack-developer |
+| Complexity | medium |
+| Dependencies | None |
+
+**Description:**
+`packages/clean-ui-editor` with clean-ui as a caret peer dependency **and** a `workspace:*` dev
+dependency — a peer entry alone does not make pnpm link it or order the builds, and without the dev
+entry type resolution falls back to a possibly-stale `dist`. CodeMirror packages are runtime
+dependencies with caret ranges, not peers and not pinned. Externalize by rule, matching the policy
+landing in clean-ui's build.
+
+**Acceptance Criteria:**
+- [ ] Builds in the workspace with clean-ui resolved from source, and type-checks clean
+- [ ] `sideEffects` declared; no global `app.component()` install (it would put CodeMirror in every
+      consumer's main bundle)
+- [ ] The no-undeclared-imports assertion passes against the built output
+
+---
+
+#### Task 1.1.2: Subpath entries and the CodeMirror re-export
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | full-stack-developer |
+| Complexity | medium |
+| Dependencies | 1.1.1 |
+
+**Description:**
+Three entries: the barrel, `/render`, and `/codemirror`. Each needs its own build entry — a module
+unreachable from the barrel is never emitted, which is exactly the lesson recorded in clean-ui's
+build config for its lazy icon module. `/codemirror` re-exports the CodeMirror surface a raw-tier
+plugin needs plus its types, so plugin authors never install CodeMirror themselves and a single
+instance is the default. Declare types per subpath, with a fallback for consumers whose module
+resolution predates exports maps.
+
+**Acceptance Criteria:**
+- [ ] All three entries resolve from a packed tarball, with working types for each
+- [ ] Importing the barrel pulls in neither the renderer nor the sanitiser
+- [ ] A plugin importing from `/codemirror` shares the editor's instance
+
+---
+
+#### Task 1.1.3: Single-instance detection
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | full-stack-developer |
+| Complexity | medium |
+| Dependencies | 1.1.2 |
+
+**Description:**
+Two copies of CodeMirror's state package break `instanceof` checks and surface as an unrecognised
+extension error that reads like a bug in the consumer's own code. Stamp identity on a versioned
+global at first construction, warn when a second differs, and translate that specific error into a
+message naming the fix — dedupe configuration or a matching range.
+
+**Acceptance Criteria:**
+- [ ] A simulated duplicate produces one actionable warning
+- [ ] The upstream error message is caught and re-explained rather than propagating raw
+- [ ] Single-instance usage is silent
+
+---
+
+### Group 1.2: Editor component
+
+#### Task 1.2.1: Mount CodeMirror in a Vue component
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | high |
+| Dependencies | 1.1.1 |
+
+**Description:**
+`CuiMarkdownEditor` mounting an editor view with the markdown language built from
+`@lezer/markdown` with GFM (not `@codemirror/lang-markdown` — see the overview's decisions), plus
+history and the default keymap. Include the `cspNonce` prop applied at construction: CodeMirror
+injects styles at runtime, the nonce cannot be added afterwards, and both intended consumers run
+content-security policies.
+
+**Acceptance Criteria:**
+- [ ] Editor mounts, accepts input, and is destroyed cleanly on unmount
+- [ ] The GFM constructs parse (verified against a document containing each)
+- [ ] With a strict style policy and a supplied nonce the editor renders styled; without one the
+      failure is documented rather than mysterious
+- [ ] No CodeMirror type appears in the barrel's declaration output
+
+---
+
+#### Task 1.2.2: Value contract
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | high |
+| Dependencies | 1.2.1 |
+
+**Description:**
+`v-model` over a markdown string, with a throttle option and — the part that matters — echo
+suppression: an incoming value equal to the current document must be a no-op. A host that
+round-trips the throttled value back will otherwise reset the cursor mid-typing, which is the
+failure mode most Vue CodeMirror wrappers have shipped at least once.
+
+**Acceptance Criteria:**
+- [ ] Content the user did not edit is never rewritten, including unknown syntax, HTML blocks and
+      frontmatter — verified byte for byte
+- [ ] Typing continuously while the host echoes a throttled value never moves the cursor or drops
+      characters
+- [ ] External value changes that genuinely differ do replace the document
+
+---
+
+#### Task 1.2.3: Mode switching
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | 1.2.1 |
+
+**Description:**
+`v-model:mode` over `wysiwyg` and `source`, implemented as one compartment reconfiguration rather
+than two editors. Includes the toolbar's built-in toggle and the prop to suppress it.
+
+**Acceptance Criteria:**
+- [ ] Switching both ways preserves document, cursor, selection and undo history — verified by
+      undoing across a switch
+- [ ] Source mode shows raw markdown with nothing hidden
+- [ ] The mode change is announced to assistive technology
+
+---
+
+#### Task 1.2.4: SSR shell
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | 1.2.1 |
+
+**Description:**
+Render a stable, correctly-sized shell on the server with no DOM access, hydrating into the editor
+without layout shift. The shell's dimensions must come from this package's own stylesheet, because
+CodeMirror's styles are injected at runtime and are therefore absent during server rendering.
+
+**Acceptance Criteria:**
+- [ ] Server rendering performs no DOM access, asserted in the node test project
+- [ ] Hydration produces no warnings and no visible shift
+- [ ] The shell reserves the same height the mounted editor occupies

--- a/docs/plans/markdown-editor-phase-1/phase-02/phase-02-journal.md
+++ b/docs/plans/markdown-editor-phase-1/phase-02/phase-02-journal.md
@@ -1,0 +1,16 @@
+# Phase 02 Journal: Reveal Layer and Theming
+
+Progress, decisions and notes logged as tasks are addressed. Entries are appended by whoever works
+a task — the tasks file tracks status, this file records why things happened.
+
+## Log
+
+_No entries yet._
+
+<!-- Template:
+### YYYY-MM-DD - Task N.G.T: Title
+**Agent:** {agent}  **Status:** {Started|Completed|Blocked}
+**Work Done:**
+**Decisions Made:**
+**Notes:**
+-->

--- a/docs/plans/markdown-editor-phase-1/phase-02/phase-02-tasks.md
+++ b/docs/plans/markdown-editor-phase-1/phase-02/phase-02-tasks.md
@@ -1,0 +1,192 @@
+# Phase 02: Reveal Layer and Theming
+
+## Overview
+
+The product. Markers hide until the caret enters, granularity follows input type, composition is
+never disturbed, and everything is styled from clean-ui tokens including CodeMirror's own chrome.
+The prototype proved this approach works; these tasks turn it into code with tests, and pay off the
+verification debt the spike left.
+
+## Status
+
+| Status      | Count |
+| ----------- | ----- |
+| Complete    | 0     |
+| In Progress | 0     |
+| Not Started | 7     |
+| Blocked     | 0     |
+| Deferred    | 0     |
+
+**Progress:** 0/7 tasks complete
+
+## Agent Assignments
+
+| Agent                                  | Focus Area                    | Tasks         |
+| -------------------------------------- | ----------------------------- | ------------- |
+| web-developer-tools:frontend-developer | Decorations, theming          | 2.1.1 – 2.2.2 |
+| developer-tools:testing-specialist     | Browser-level verification    | 2.3.1, 2.3.2  |
+
+## Tasks
+
+### Group 2.1: Decoration layer
+
+#### Task 2.1.1: Marker hiding and reveal on caret entry
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | high |
+| Dependencies | Phase 01 |
+
+**Description:**
+Walk the syntax tree over visible ranges, style each supported construct, and hide its marker
+children unless the selection is inside. Hiding must use a mark decoration with zero-size styling,
+**not** `Decoration.replace()`, which removes characters from the DOM and therefore from the
+accessibility tree. Recompute on document, selection and viewport changes — and on a granularity
+change, which sets none of those flags and was the bug the prototype caught.
+
+**Acceptance Criteria:**
+- [ ] For emphasis, strong, inline code, heading, link and strikethrough: markers hidden with the
+      caret away, revealed on entry, text unchanged throughout
+- [ ] The full markdown including markers is present in the accessibility tree
+- [ ] Switching granularity alone re-renders decorations
+- [ ] Decoration work stays within the viewport on a 10,000-line document
+
+---
+
+#### Task 2.1.2: Granularity and input-type detection
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | 2.1.1 |
+
+**Description:**
+Construct granularity for pointer input, whole-line for touch, following the most recent input type
+so hybrid devices behave sensibly. Line granularity exists because landing a caret between two
+asterisks with a fingertip is not a reasonable requirement.
+
+**Acceptance Criteria:**
+- [ ] Line granularity reveals every marker on the caret's line; construct granularity reveals only
+      the containing construct
+- [ ] A touch-type pointer event switches granularity; a mouse event switches it back
+- [ ] Granularity is inspectable for tests without exposing internals as public API
+
+---
+
+#### Task 2.1.3: Composition guard
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | 2.1.1 |
+
+**Description:**
+Suspend decoration recalculation while an IME composition is active. Changing the DOM under a
+composition can displace the candidate window or abort composition, which would make the editor
+unusable for a whole class of users. Resume and recompute once composition ends.
+
+**Acceptance Criteria:**
+- [ ] No decoration update occurs between composition start and end
+- [ ] Composed text lands intact and decorations are correct immediately after
+- [ ] Covered by a browser-level test driving the real composition path
+
+---
+
+### Group 2.2: Theming
+
+#### Task 2.2.1: Editor chrome and syntax colours from tokens
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | Phase 01 |
+
+**Description:**
+Build the editor theme and the syntax highlight style from `--cui-*` tokens. CodeMirror's language
+package ships its own palette, which is easy to wire up unchanged and violates the
+no-hardcoded-colours rule invisibly until a theme switch or contrast audit exposes it. Respect the
+density scale for padding.
+
+**Acceptance Criteria:**
+- [ ] No colour literal in the package's source or emitted CSS
+- [ ] Highlight tokens pass the contrast audit in light and dark across all themes
+- [ ] Density classes change spacing but never type size
+
+---
+
+#### Task 2.2.2: Dark mode through the colour-scheme signal
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | 2.2.1, clean-ui 1.2.0 |
+
+**Description:**
+Tokens alone are not sufficient: CodeMirror picks its base-theme dark rules from a flag fixed when
+configuration is built, while clean-ui's dark mode is a runtime class on an arbitrary ancestor.
+Drive that flag from clean-ui's colour-scheme signal through a compartment, or the caret and
+selection layers stay light with no obvious cause.
+
+**Acceptance Criteria:**
+- [ ] Toggling the class at runtime updates caret, selection layer and syntax colours without a
+      remount
+- [ ] A dark class scoped to a subtree affects only an editor inside it
+- [ ] Verified in a real browser, since this is invisible to jsdom
+
+---
+
+### Group 2.3: Verification debt from the spike
+
+#### Task 2.3.1: Touch behaviour on a physical device
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | testing-specialist |
+| Complexity | medium |
+| Dependencies | 2.1.2 |
+
+**Description:**
+The prototype synthesised touch events; selection handles, caret placement by tap and the on-screen
+keyboard were never exercised. Run the reveal model on a real phone and record what breaks. This is
+the requirement's own motivation — the touch model exists because of a mobile audit — so it cannot
+rest on synthesised events.
+
+**Acceptance Criteria:**
+- [ ] Tap-to-place-caret reveals the expected line on iOS and Android
+- [ ] Selection handles can extend a selection across a hidden marker without surprises
+- [ ] The on-screen keyboard does not obscure or displace the editor's own chrome
+- [ ] Findings recorded, with anything unfixable stated as a known limitation
+
+---
+
+#### Task 2.3.2: Screen reader pass
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | testing-specialist |
+| Complexity | medium |
+| Dependencies | 2.1.1 |
+
+**Description:**
+The accessibility gate proved the markdown is exposed in the tree; nobody has heard it. Read a
+representative document with a screen reader and confirm the experience is coherent rather than
+merely present — marker noise is expected and accepted by the spec, but it should not be
+misleading.
+
+**Acceptance Criteria:**
+- [ ] A document with headings, emphasis, code and links read end to end on at least one screen
+      reader
+- [ ] Caret navigation traverses exactly the characters announced
+- [ ] Any surprise is either fixed or documented as a known characteristic of the model

--- a/docs/plans/markdown-editor-phase-1/phase-03/phase-03-journal.md
+++ b/docs/plans/markdown-editor-phase-1/phase-03/phase-03-journal.md
@@ -1,0 +1,16 @@
+# Phase 03 Journal: Plugin System
+
+Progress, decisions and notes logged as tasks are addressed. Entries are appended by whoever works
+a task — the tasks file tracks status, this file records why things happened.
+
+## Log
+
+_No entries yet._
+
+<!-- Template:
+### YYYY-MM-DD - Task N.G.T: Title
+**Agent:** {agent}  **Status:** {Started|Completed|Blocked}
+**Work Done:**
+**Decisions Made:**
+**Notes:**
+-->

--- a/docs/plans/markdown-editor-phase-1/phase-03/phase-03-tasks.md
+++ b/docs/plans/markdown-editor-phase-1/phase-03/phase-03-tasks.md
@@ -1,0 +1,214 @@
+# Phase 03: Plugin System
+
+## Overview
+
+The public extension API, built before any built-in plugin so the built-ins prove it. If a built-in
+needs privileged access the tier is wrong — that is the design signal the specification is built
+around, and the reason the plugin record carries construct, paste and decoration declarations rather
+than just commands.
+
+## Status
+
+| Status      | Count |
+| ----------- | ----- |
+| Complete    | 0     |
+| In Progress | 0     |
+| Not Started | 8     |
+| Blocked     | 0     |
+| Deferred    | 0     |
+
+**Progress:** 0/8 tasks complete
+
+## Agent Assignments
+
+| Agent                                  | Focus Area                       | Tasks         |
+| -------------------------------------- | -------------------------------- | ------------- |
+| web-developer-tools:frontend-developer | Plugin runtime, command context  | 3.1.1 – 3.2.3 |
+| developer-tools:testing-specialist     | Conflict, failure and reactivity | 3.2.4         |
+
+## Tasks
+
+### Group 3.1: Plugin record and command context
+
+#### Task 3.1.1: `definePlugin` and the plugin record
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | high |
+| Dependencies | Phase 01 |
+
+**Description:**
+The factory and its typed record: `id`, `commands`, and optionally `toolbar`, `keymap`, the
+`constructs` the plugin authorises, `paste` rules with an explicit degrade target, `decorations`
+rules mapping parser nodes to reveal behaviour, and raw CodeMirror `extensions`. Stamp the API
+version so an incompatible plugin is rejected at registration with a named mismatch rather than
+failing later at a missing helper.
+
+**Acceptance Criteria:**
+- [ ] A plugin declaring every field registers and all fields take effect
+- [ ] Author-facing types are exported and usable from another package
+- [ ] An incompatible API version is rejected with a message naming the mismatch
+- [ ] No CodeMirror type leaks into the declarative tier's declarations
+
+---
+
+#### Task 3.1.2: Command context and helpers
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | high |
+| Dependencies | 3.1.1 |
+
+**Description:**
+Commands are synchronous and return a boolean, matching CodeMirror's own convention. The context
+carries the selection, document text, and insert / wrap / replace helpers — the same helpers the
+built-ins use. Each command's changes form exactly one undo step however many edits it makes, which
+does not happen for free with programmatic multi-part edits.
+
+**Acceptance Criteria:**
+- [ ] Every helper works with an empty selection, a partial selection and a multi-line selection
+- [ ] A command making several edits undoes and redoes as one step
+- [ ] Returning false leaves the document untouched and lets other handlers run
+
+---
+
+#### Task 3.1.3: `isActive` query
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | 3.1.2 |
+
+**Description:**
+A command may expose `isActive` so the toolbar can render pressed state and the command can decide
+toggle-on versus toggle-off. Without it, neither toggling nor pressed state is expressible — the
+gap the DX review found in the original design.
+
+**Acceptance Criteria:**
+- [ ] A toolbar button shows pressed state while the caret sits inside its construct
+- [ ] The query is cheap enough to run on every selection change without lag
+- [ ] Absent `isActive` degrades to a never-pressed button rather than an error
+
+---
+
+#### Task 3.1.4: The `collect` seam for dialogs
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | high |
+| Dependencies | 3.1.2 |
+
+**Description:**
+Asynchronous work goes through a named seam rather than async commands: `collect` opens a dialog and
+resolves with values, and the editor owns position validity across the await. Phase 2's upload
+reservation seam is designed to slot in beside it. The link dialog is its first consumer, which is
+deliberate — the seam is proven in v1 rather than retrofitted when uploads arrive.
+
+**Acceptance Criteria:**
+- [ ] A command can collect values and then edit, with positions still valid if the user typed
+      during the dialog
+- [ ] Cancelling leaves the document untouched
+- [ ] The resulting edit is one undo step; the awaited interaction is not claimed to be atomic
+
+---
+
+### Group 3.2: Registry behaviour
+
+#### Task 3.2.1: Registration, precedence and conflicts
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | high |
+| Dependencies | 3.1.1 |
+
+**Description:**
+Precedence is array order with the default preset applied first, so a later registration overrides
+an earlier one — which is how a consumer replaces a built-in on purpose. Note this is the opposite
+of CodeMirror keymap semantics, where the first handler returning true wins, so the mapping must be
+implemented deliberately rather than by passing the array through. Duplicate ids and conflicting
+keybindings warn, naming both contributors.
+
+**Acceptance Criteria:**
+- [ ] A consumer plugin overriding a built-in command id wins, with a warning naming both
+- [ ] Two plugins binding one key resolve by order, with a warning
+- [ ] A raw extension using an explicit precedence override escapes the model, and that is
+      documented rather than silently surprising
+- [ ] A unit test asserts the shipped default preset has no internal conflict
+
+---
+
+#### Task 3.2.2: Reactive plugins with validate-before-apply
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | high |
+| Dependencies | 3.2.1 |
+
+**Description:**
+Changing `plugins` reconfigures toolbar, commands, keymap, construct policy and extensions in place,
+preserving document, undo history and cursor. Build and validate the replacement configuration
+*before* dispatching: a failed reconfiguration would otherwise leave a dead editor holding the
+user's document.
+
+**Acceptance Criteria:**
+- [ ] Adding a plugin to a mounted editor updates the toolbar with no loss of document, history or
+      cursor
+- [ ] An invalid configuration keeps the previous one and reports the failure
+- [ ] Documentation warns that plugin instances should be created once, not inline in a template
+
+---
+
+#### Task 3.2.3: Failure containment and the imperative API
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | 3.2.1 |
+
+**Description:**
+Guard every command invocation path — toolbar, keymap, slash menu, imperative call — so a throwing
+plugin surfaces through an error hook naming it and leaves editing alive. Install each plugin's raw
+extensions separately so a failing one can be dropped without a remount; the raw tier is not
+sandboxed, and the documentation must say so. Expose the host-facing API: focus, blur, run a command
+by id, read the selection, and reach the view through one named accessor.
+
+**Acceptance Criteria:**
+- [ ] A throwing command reports through the hook and the editor stays usable
+- [ ] Running a command by id from the host produces the same edit as its toolbar button
+- [ ] CodeMirror types the public API mentions are re-exported, so a consumer never resolves
+      CodeMirror itself
+
+---
+
+#### Task 3.2.4: Plugin system test suite
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | testing-specialist |
+| Complexity | high |
+| Dependencies | 3.2.3 |
+
+**Description:**
+Cover the registry's contract: precedence, conflicts, override, reactivity with state preservation,
+invalid configuration rollback, failure containment, and API version rejection. These are the
+behaviours a third-party plugin author depends on, so they are the ones that must not regress
+quietly.
+
+**Acceptance Criteria:**
+- [ ] Each behaviour above has a test that fails when the behaviour is removed
+- [ ] Tests run in the jsdom project where possible, browser project where layout is involved

--- a/docs/plans/markdown-editor-phase-1/phase-04/phase-04-journal.md
+++ b/docs/plans/markdown-editor-phase-1/phase-04/phase-04-journal.md
@@ -1,0 +1,16 @@
+# Phase 04 Journal: Built-in Plugins, Slash Menu and Paste
+
+Progress, decisions and notes logged as tasks are addressed. Entries are appended by whoever works
+a task — the tasks file tracks status, this file records why things happened.
+
+## Log
+
+_No entries yet._
+
+<!-- Template:
+### YYYY-MM-DD - Task N.G.T: Title
+**Agent:** {agent}  **Status:** {Started|Completed|Blocked}
+**Work Done:**
+**Decisions Made:**
+**Notes:**
+-->

--- a/docs/plans/markdown-editor-phase-1/phase-04/phase-04-tasks.md
+++ b/docs/plans/markdown-editor-phase-1/phase-04/phase-04-tasks.md
@@ -1,0 +1,214 @@
+# Phase 04: Built-in Plugins, Slash Menu and Paste
+
+## Overview
+
+Every formatting action written as an ordinary plugin against the Phase 03 API, shipped as presets.
+This phase is where the plugin tier gets proven or found wanting: if any action needs privileged
+access, Phase 03 is incomplete and comes back rather than the built-in getting a special case.
+
+## Status
+
+| Status      | Count |
+| ----------- | ----- |
+| Complete    | 0     |
+| In Progress | 0     |
+| Not Started | 8     |
+| Blocked     | 0     |
+| Deferred    | 0     |
+
+**Progress:** 0/8 tasks complete
+
+## Agent Assignments
+
+| Agent                                  | Focus Area                      | Tasks         |
+| -------------------------------------- | ------------------------------- | ------------- |
+| web-developer-tools:frontend-developer | Plugins, toolbar, dialogs       | 4.1.1 – 4.3.2 |
+| developer-tools:testing-specialist     | Policy and paste coverage       | 4.3.3         |
+
+## Tasks
+
+### Group 4.1: Formatting plugins and toolbar
+
+#### Task 4.1.1: Inline and block formatting plugins
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | high |
+| Dependencies | Phase 03 |
+
+**Description:**
+Bold, italic, strikethrough, inline code, headings one to three, bulleted list, numbered list, task
+list, blockquote, code fence and horizontal rule — each a plugin declaring its command, toolbar
+entry, keybinding, construct and decoration rule. No table plugin: tables ship complete in phase 2,
+and an insert button without cell navigation advertises an experience that is not there.
+
+**Acceptance Criteria:**
+- [ ] Each action applies, toggles off, and behaves with an empty, partial and multi-line selection
+- [ ] Each is one undo step
+- [ ] No action reaches inside the editor for anything the plugin API does not expose
+- [ ] Icons used are registered by this package, so they render in a consumer app rather than
+      falling back to a placeholder glyph
+
+---
+
+#### Task 4.1.2: Toolbar with config and slot
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | 4.1.1 |
+
+**Description:**
+Default toolbar from the preset, a prop to subset and order by command id including plugin ids, and
+a slot to replace it entirely. Built from clean-ui components, keyboard operable as one tab stop with
+arrow navigation, and horizontally scrollable when it overflows rather than clipping — the failure
+this library already fixed once in its tab bar.
+
+**Acceptance Criteria:**
+- [ ] Zero configuration yields the full default set; a subset yields exactly what was named
+- [ ] One tab stop, arrow-key navigation, all controls at least 24px
+- [ ] At 360px width the toolbar scrolls and every action stays reachable
+- [ ] Pressed state reflects `isActive`
+
+---
+
+#### Task 4.1.3: Presets and composition
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | 4.1.1 |
+
+**Description:**
+Export plugins individually and as presets, including the default used when `plugins` is not
+supplied. Support composing a custom set, extending the default, and configuring a preset to omit
+individual actions — the "I don't want italic" case that motivated the construct policy.
+
+**Acceptance Criteria:**
+- [ ] Zero-config, explicit list, extend-default and omit-one all work
+- [ ] An app omitting a plugin does not ship it, verified in the fixture build
+- [ ] Excluding italic removes button, shortcut, slash entry and command
+
+---
+
+### Group 4.2: List continuation and dialogs
+
+#### Task 4.2.1: List typing ergonomics
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | 4.1.1 |
+
+**Description:**
+Enter continues the item, Enter on an empty item exits, Tab and Shift-Tab indent and outdent, task
+items continue unchecked, ordered lists renumber. Reuse `@codemirror/lang-markdown`'s continuation
+commands, which the prototype measured as tree-shaking free of that package's HTML grammar for
+2.3 kB — do not reimplement them, and do not import the whole language.
+
+**Acceptance Criteria:**
+- [ ] Each behaviour above verified for bulleted, ordered and task lists
+- [ ] Nested lists indent and outdent to the right level
+- [ ] The bundle assertion confirms no HTML grammar arrived with the commands
+
+---
+
+#### Task 4.2.2: Link and image dialogs
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | 4.1.1, Phase 03 |
+
+**Description:**
+Dialogs built from clean-ui components, driven through the `collect` seam — their first real
+consumer. A URL-looking selection pre-fills the URL; any other selection becomes the link label
+rather than being discarded. URL schemes are allowlisted, since a `javascript:` URL in link syntax is
+valid CommonMark and the likeliest real vulnerability in this feature. Mode switching is blocked
+while a dialog is open.
+
+**Acceptance Criteria:**
+- [ ] Selecting text and inserting a link produces a labelled link, not a discarded selection
+- [ ] A `javascript:` URL is refused with a clear message
+- [ ] Cancelling changes nothing; confirming is one undo step
+- [ ] Images are inserted by URL only — no upload affordance exists in v1
+
+---
+
+### Group 4.3: Slash menu, paste and policy
+
+#### Task 4.3.1: Slash menu
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | high |
+| Dependencies | 4.1.1 |
+
+**Description:**
+Typing `/` opens a filtered palette of insert commands built on CodeMirror's autocomplete, sourced
+from plugin commands carrying a label and icon — so a plugin appears in both surfaces from one
+declaration. Follows the combobox pattern for keyboard operation, and leaves the literal text when
+dismissed.
+
+**Acceptance Criteria:**
+- [ ] Filtering, arrow navigation, Enter to run, Escape to dismiss leaving the typed text
+- [ ] A third-party plugin command appears with no extra declaration
+- [ ] An excluded construct's command does not appear
+- [ ] Announced per the combobox pattern
+
+---
+
+#### Task 4.3.2: Paste conversion and construct policy
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | high |
+| Dependencies | 4.1.1 |
+
+**Description:**
+HTML paste converts to markdown through the plugins' paste rules, honouring the loaded construct set
+and degrading to the nearest available representation or plain text. The converter must never emit
+raw HTML: an unrecognised element becomes text, so markup pasted from a hostile page cannot be
+laundered into stored content. A modifier paste inserts plain text. Pasted image files are refused
+with a localised message.
+
+**Acceptance Criteria:**
+- [ ] Pasting a rendered page preserves headings, emphasis, links, lists and a table
+- [ ] With italic excluded, pasted emphasis arrives as plain text
+- [ ] A script tag or unknown element yields text, never raw HTML, in the stored markdown
+- [ ] An image file paste inserts nothing and explains why
+
+---
+
+#### Task 4.3.3: Policy and paste test suite
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | testing-specialist |
+| Complexity | high |
+| Dependencies | 4.3.2 |
+
+**Description:**
+The construct policy is the feature most likely to rot, because it spans four subsystems — commands,
+slash menu, paste and decoration — and a gap in any one of them silently breaks the guarantee.
+Cover each exclusion across all four.
+
+**Acceptance Criteria:**
+- [ ] For at least three excluded constructs, all four surfaces are verified absent
+- [ ] Paste conversion tested against real clipboard HTML from a browser, not hand-written fixtures
+- [ ] Hand-typed markers for an excluded construct stay unstyled literal text

--- a/docs/plans/markdown-editor-phase-1/phase-05/phase-05-journal.md
+++ b/docs/plans/markdown-editor-phase-1/phase-05/phase-05-journal.md
@@ -1,0 +1,16 @@
+# Phase 05 Journal: Form Integration, Limits and Messages
+
+Progress, decisions and notes logged as tasks are addressed. Entries are appended by whoever works
+a task — the tasks file tracks status, this file records why things happened.
+
+## Log
+
+_No entries yet._
+
+<!-- Template:
+### YYYY-MM-DD - Task N.G.T: Title
+**Agent:** {agent}  **Status:** {Started|Completed|Blocked}
+**Work Done:**
+**Decisions Made:**
+**Notes:**
+-->

--- a/docs/plans/markdown-editor-phase-1/phase-05/phase-05-tasks.md
+++ b/docs/plans/markdown-editor-phase-1/phase-05/phase-05-tasks.md
@@ -1,0 +1,138 @@
+# Phase 05: Form Integration, Limits and Messages
+
+## Overview
+
+Make the editor a form control that behaves like every other clean-ui control, and localise it
+through the library's catalog. The length limit is the one place copying `CuiTextarea` would be
+wrong, because truncating markdown corrupts it.
+
+## Status
+
+| Status      | Count |
+| ----------- | ----- |
+| Complete    | 0     |
+| In Progress | 0     |
+| Not Started | 5     |
+| Blocked     | 0     |
+| Deferred    | 0     |
+
+**Progress:** 0/5 tasks complete
+
+## Agent Assignments
+
+| Agent                                  | Focus Area                   | Tasks         |
+| -------------------------------------- | ---------------------------- | ------------- |
+| web-developer-tools:frontend-developer | Form control, limits, i18n   | 5.1.1 – 5.2.2 |
+| developer-tools:testing-specialist     | Form parity coverage         | 5.1.3         |
+
+## Tasks
+
+### Group 5.1: Form control
+
+#### Task 5.1.1: Compose `FormControlProps`
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | Phase 01 |
+
+**Description:**
+Label, description, error, error message, required, readonly and disabled, following the library's
+error convention — the wrapper's own border recoloured with the message below — plus `aria-invalid`.
+Note the boundary discovered during review: `required` is presentational throughout clean-ui, since
+`CuiForm` validates only through a resolver and has no field registration. Do not build a private
+validation path here to fake it.
+
+**Acceptance Criteria:**
+- [ ] Label, description and error render identically to a sibling `CuiTextarea`
+- [ ] `required` renders the indicator and sets `aria-required`
+- [ ] `readonly` allows selection but not editing; `disabled` removes it from the tab order
+- [ ] A resolver error for the field renders on the editor
+
+---
+
+#### Task 5.1.2: Placeholder and empty state
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | low |
+| Dependencies | 5.1.1 |
+
+**Description:**
+A `placeholder` prop for the empty state, matching `CuiInput` and `CuiTextarea`. Small, and its
+absence would be noticed immediately by anyone dropping the editor into an existing form.
+
+**Acceptance Criteria:**
+- [ ] Placeholder shows only when the document is empty
+- [ ] It is not selectable and never becomes part of the value
+- [ ] Styled with the same token as sibling controls
+
+---
+
+#### Task 5.1.3: Form parity tests
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | testing-specialist |
+| Complexity | medium |
+| Dependencies | 5.1.1 |
+
+**Description:**
+Assert parity with a sibling control rather than asserting the editor's own markup: same label
+association, same error presentation, same resolver behaviour. Parity is the actual requirement, and
+it survives refactors that a markup snapshot would not.
+
+**Acceptance Criteria:**
+- [ ] A form containing both an editor and a textarea presents both identically
+- [ ] These assertions run in the jsdom project, and are the documented jsdom-safe set for consumers
+
+---
+
+### Group 5.2: Limits and localisation
+
+#### Task 5.2.1: `maxLength` that refuses rather than truncates
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | 5.1.1 |
+
+**Description:**
+Count markdown source characters, since that is what a storage column holds, and show a counter as
+`CuiTextarea` does. Reject the edit that would exceed the limit instead of truncating: cutting at a
+character boundary can split a link or open a code fence and corrupt everything after it. An
+oversized paste is refused with the overage stated.
+
+**Acceptance Criteria:**
+- [ ] Typing stops at the limit; the counter shows the error state
+- [ ] An oversized paste is refused with a message naming the overage, and inserts nothing
+- [ ] No document is ever left with a split construct or an opened fence
+- [ ] Documentation states the limit is client-side only and storage must be validated server-side
+
+---
+
+#### Task 5.2.2: Message namespace
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | clean-ui 1.2.0 |
+
+**Description:**
+Every user-visible string — toolbar labels, dialog fields, refusal messages, the mode toggle, slash
+menu entries, counter text — resolves through clean-ui's catalog under this package's namespace,
+declared via the augmentation seam so it is typed rather than loose.
+
+**Acceptance Criteria:**
+- [ ] No user-visible string is hardcoded in a component
+- [ ] A consumer overrides any string through a custom catalog, with type checking
+- [ ] The namespace appears in the Localization documentation

--- a/docs/plans/markdown-editor-phase-1/phase-06/phase-06-journal.md
+++ b/docs/plans/markdown-editor-phase-1/phase-06/phase-06-journal.md
@@ -1,0 +1,16 @@
+# Phase 06 Journal: Render Subpath
+
+Progress, decisions and notes logged as tasks are addressed. Entries are appended by whoever works
+a task — the tasks file tracks status, this file records why things happened.
+
+## Log
+
+_No entries yet._
+
+<!-- Template:
+### YYYY-MM-DD - Task N.G.T: Title
+**Agent:** {agent}  **Status:** {Started|Completed|Blocked}
+**Work Done:**
+**Decisions Made:**
+**Notes:**
+-->

--- a/docs/plans/markdown-editor-phase-1/phase-06/phase-06-tasks.md
+++ b/docs/plans/markdown-editor-phase-1/phase-06/phase-06-tasks.md
@@ -1,0 +1,120 @@
+# Phase 06: Render Subpath
+
+## Overview
+
+Rendering markdown to HTML for display, kept entirely out of the core entry. The editor never needs
+it — live preview is decorations, not HTML — so the only reason it exists is that consumers displaying
+saved content should not have to solve it twice.
+
+The design deliberately avoids making this library the security boundary: the adapter is injectable so
+an application supplies whatever it already uses, and the supplied implementation escapes raw HTML by
+configuration rather than by sanitising.
+
+## Status
+
+| Status      | Count |
+| ----------- | ----- |
+| Complete    | 0     |
+| In Progress | 0     |
+| Not Started | 4     |
+| Blocked     | 0     |
+| Deferred    | 0     |
+
+**Progress:** 0/4 tasks complete
+
+## Agent Assignments
+
+| Agent                                  | Focus Area                | Tasks         |
+| -------------------------------------- | ------------------------- | ------------- |
+| web-developer-tools:frontend-developer | Adapter, viewer           | 6.1.1 – 6.1.3 |
+| developer-tools:testing-specialist     | Security coverage         | 6.1.4         |
+
+## Tasks
+
+### Group 6.1: Adapter and viewer
+
+#### Task 6.1.1: The adapter contract
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | Phase 01 |
+
+**Description:**
+A synchronous adapter type returning a value produced only by an explicit trust-marking helper, so the
+type itself says the caller is asserting the HTML is safe to inject. Synchronous in v1: widening to
+allow a promise later is additive, narrowing would be breaking. Document that phase 1.5's split
+preview will consume this same contract.
+
+**Acceptance Criteria:**
+- [ ] An adapter returning a plain string does not type-check; trust must be marked explicitly
+- [ ] The contract is documented with a worked example using a third-party renderer
+- [ ] Nothing in the core entry imports the adapter implementation
+
+---
+
+#### Task 6.1.2: Viewer component
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | 6.1.1 |
+
+**Description:**
+A viewer taking a markdown string and an adapter. It applies clean-ui's typography layer itself
+rather than documenting that consumers should, and it catches an adapter that throws — falling back to
+escaped source with a developer warning, never blanking and never propagating into the component tree.
+
+**Acceptance Criteria:**
+- [ ] Rendered output inherits typography styling with no extra consumer setup
+- [ ] A throwing adapter yields escaped source plus one warning
+- [ ] Re-rendering on value change does not leak DOM or listeners
+
+---
+
+#### Task 6.1.3: Supplied adapter at `/render`
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | 6.1.1 |
+
+**Description:**
+A ready-made adapter for applications with no renderer of their own. It escapes raw HTML by
+configuring the parser not to emit it, which needs no sanitiser and keeps the subpath free of any DOM
+dependency so it also runs during server rendering. Allowing raw HTML requires the consumer to supply
+their own sanitiser — this library does not bundle one. URL schemes are allowlisted.
+
+**Acceptance Criteria:**
+- [ ] Raw HTML in the source is escaped by default
+- [ ] Enabling raw HTML without supplying a sanitiser is refused, not silently permitted
+- [ ] The adapter runs under the node test environment, proving no DOM dependency
+- [ ] Importing `/render` adds the parser to a consumer bundle; importing the barrel does not
+
+---
+
+#### Task 6.1.4: Security test suite
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | testing-specialist |
+| Complexity | medium |
+| Dependencies | 6.1.3 |
+
+**Description:**
+The XSS surface is wider than raw HTML blocks, and the trust boundary needs asserting rather than
+describing: script tags, event-handler attributes, `javascript:` and `data:` URLs in both link and
+image syntax, and HTML smuggled through paste then rendered.
+
+**Acceptance Criteria:**
+- [ ] Each vector above is neutralised by default and covered by a named test
+- [ ] Enabling raw HTML with a sanitiser present still neutralises scheme-based vectors
+- [ ] A test documents the boundary: the same markdown rendered by a different renderer is the
+      consumer's responsibility, and the server is the authority

--- a/docs/plans/markdown-editor-phase-1/phase-07/phase-07-journal.md
+++ b/docs/plans/markdown-editor-phase-1/phase-07/phase-07-journal.md
@@ -1,0 +1,16 @@
+# Phase 07 Journal: Documentation Site
+
+Progress, decisions and notes logged as tasks are addressed. Entries are appended by whoever works
+a task — the tasks file tracks status, this file records why things happened.
+
+## Log
+
+_No entries yet._
+
+<!-- Template:
+### YYYY-MM-DD - Task N.G.T: Title
+**Agent:** {agent}  **Status:** {Started|Completed|Blocked}
+**Work Done:**
+**Decisions Made:**
+**Notes:**
+-->

--- a/docs/plans/markdown-editor-phase-1/phase-07/phase-07-tasks.md
+++ b/docs/plans/markdown-editor-phase-1/phase-07/phase-07-tasks.md
@@ -1,0 +1,141 @@
+# Phase 07: Documentation Site
+
+## Overview
+
+`apps/editor-docs`, the editor's own documentation site and its first real consumer. Dogfooding is the
+point: if the plugin guide's examples are not the library's own source, the plugin API is not being
+tested by its own documentation.
+
+## Status
+
+| Status      | Count |
+| ----------- | ----- |
+| Complete    | 0     |
+| In Progress | 0     |
+| Not Started | 5     |
+| Blocked     | 0     |
+| Deferred    | 0     |
+
+**Progress:** 0/5 tasks complete
+
+## Agent Assignments
+
+| Agent                                    | Focus Area                | Tasks         |
+| ---------------------------------------- | ------------------------- | ------------- |
+| web-developer-tools:frontend-developer   | Docs app and examples     | 7.1.1 – 7.2.2 |
+| developer-tools:documentation-expert     | Plugin authoring guide    | 7.2.1         |
+
+## Tasks
+
+### Group 7.1: Site and examples
+
+#### Task 7.1.1: Scaffold the docs app
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | Phase 01 |
+
+**Description:**
+A second docs app resolving clean-ui and the editor through the **shared alias module** from the
+platform work — if this app resolves clean-ui differently from the existing docs site, two copies load
+and every duplicate-instance symptom appears in our own documentation. Built with its own base path so
+the composed Pages artifact can host both.
+
+**Acceptance Criteria:**
+- [ ] Uses the shared alias module; no local alias list
+- [ ] Builds with a base path and deep links work from the composed artifact
+- [ ] Theme switcher, dark mode and density controls work as on the main site
+
+---
+
+#### Task 7.1.2: Component reference and live examples
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | 7.1.1, Phase 05 |
+
+**Description:**
+Every prop, event, slot and command id documented, with live examples: default editor, mode switching,
+a form-integrated editor beside a `CuiTextarea` for parity, a length-limited editor, a custom toolbar
+subset, and an editor with a construct excluded so the policy is demonstrable rather than described.
+
+**Acceptance Criteria:**
+- [ ] Reference tables cover the full public API with no omissions
+- [ ] Each example is interactive and shows its source
+- [ ] The form example visibly demonstrates parity with a sibling control
+
+---
+
+#### Task 7.1.3: Accessibility and mobile demonstration
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | low |
+| Dependencies | 7.1.2 |
+
+**Description:**
+A page stating the accessibility characteristics honestly, including the one that surprises people: in
+WYSIWYG mode a screen reader reads the markdown markers, because hiding is visual only and nothing is
+concealed from assistive technology. Plus a width-adjustable demo showing toolbar overflow and the
+touch reveal granularity.
+
+**Acceptance Criteria:**
+- [ ] The screen-reader behaviour is documented as a deliberate characteristic, not omitted
+- [ ] Keyboard shortcuts are listed in full
+- [ ] The narrow-viewport demo shows the toolbar scrolling rather than clipping
+
+---
+
+### Group 7.2: Guides
+
+#### Task 7.2.1: Plugin authoring guide
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | documentation-expert |
+| Complexity | medium |
+| Dependencies | Phase 03, Phase 04 |
+
+**Description:**
+The declarative tier first, with the timestamp plugin as the worked example, then the raw tier with its
+stability caveat stated plainly: the declarative tier is protected across majors, while raw extensions
+track the CodeMirror major they were built against and may break in a minor. Show that CodeMirror comes
+from this package's subpath, and why. Include the conflict and precedence rules, since a plugin author
+hitting them without documentation will assume a bug.
+
+**Acceptance Criteria:**
+- [ ] A reader can write a working plugin from the guide alone
+- [ ] Both tiers documented with the stability difference explicit
+- [ ] The examples are the library's own built-in plugins, not parallel inventions
+- [ ] Precedence, conflict warnings and the API version check are explained
+
+---
+
+#### Task 7.2.2: Integration and testing guide
+
+| Field | Value |
+|-------|-------|
+| Status | `[ ]` Not Started |
+| Assigned | frontend-developer |
+| Complexity | medium |
+| Dependencies | 7.1.2, Phase 06 |
+
+**Description:**
+What an integrator needs that is not a prop: installing with the right peer versions, the CSP nonce for
+a policy-enforcing app, server rendering, choosing a render adapter or supplying their own, the
+documented test contract with its jsdom-safe and browser-only split, and the bundle cost with the
+figure that justifies not shipping a renderer in core.
+
+**Acceptance Criteria:**
+- [ ] Covers install, CSP, SSR, rendering choice, testing and bundle cost
+- [ ] The test contract lists the stable hooks and which assertions hold in jsdom
+- [ ] A Laravel-style and a Tauri-style note each cover their specific concern

--- a/docs/platform/multi-package-build-and-release.md
+++ b/docs/platform/multi-package-build-and-release.md
@@ -142,9 +142,12 @@ build, which nothing in CI performs.
 ## Known Gaps Not Addressed Here
 
 - There is no linter in this repository: no eslint, prettier or biome configuration exists, and
-  the root `lint` script matches no package script. Any acceptance criterion asserting "linting
-  passes" is currently false. Worth resolving before a second package doubles the surface, but
-  it is a separate piece of work.
+  the root `lint` script matches no package script. **Decision: no linter is being introduced**,
+  and every acceptance criterion asserting "linting passes" has been struck rather than left
+  false. Type checking through `vue-tsc` remains the automated code gate. Adding a linter later
+  is a separate piece of work, and would come with its own decision about formatting the existing
+  code. Note the root `lint` script still exists and silently matches nothing, which is worth
+  removing whenever someone next touches the root scripts.
 - `scripts/check-contrast.mjs` reads clean-ui's `theme.css` with a hardcoded token pair list.
   Extending the audit to a second package's tokens is real work, and any requirement claiming
   a satellite package is "verified by the same contrast audit" depends on it.

--- a/docs/platform/multi-package-build-and-release.md
+++ b/docs/platform/multi-package-build-and-release.md
@@ -1,0 +1,160 @@
+# Platform: Multi-Package Build, Release and Verification
+
+**Status**: Draft
+**Created**: 2026-07-29
+**Applies to**: this monorepo as it grows past one published package. Written while specifying
+`@itguy614/clean-ui-editor` (see `docs/features/markdown-editor.md`), but every decision here
+is intended to serve any future satellite package.
+
+## Problem Statement
+
+### Current State
+
+The repository publishes exactly one package and the tooling assumes it everywhere:
+
+- `.github/workflows/publish-npm.yml` hardcodes `working-directory: packages/clean-ui`, one
+  `npm view` version check, one `CHANGELOG.md` section extracted by version, and one
+  `gh release create "v$VERSION"`.
+- `.github/workflows/ci.yml` hardcodes `--filter @itguy614/clean-ui` and type-checks exactly
+  one docs app.
+- `.github/workflows/deploy-docs.yml` uploads `apps/docs/dist` as the entire Pages artifact.
+- `packages/clean-ui/vite.config.ts` externalizes a hand-written list of four specifiers.
+- `apps/docs/vite.config.ts` aliases `@itguy614/clean-ui` to source, so nothing in CI ever
+  exercises the published artifact, its `exports` map, or peer resolution.
+- The only size measurement, `scripts/postbuild.mjs`, reports the library's own `dist` sizes,
+  not what reaches a consumer's bundle.
+
+### Desired State
+
+A second package can be built, tested, published and documented without rewriting the
+pipeline, and the guarantees the packages advertise — tree-shaking, no accidental
+dependencies, single instances of shared runtime state — are verified mechanically rather than
+asserted in a changelog.
+
+### Gap
+
+Every workflow is single-package by construction, and the two guarantees that have already
+been broken once in this repository (a stylesheet shipping Tailwind utilities, an icon barrel
+defeating tree-shaking) are exactly the class of problem that only shows up in a consumer's
+build, which nothing in CI performs.
+
+## Requirements
+
+### Dependency policy
+
+- P1: A published package externalizes dependencies **by rule**, not by a maintained list.
+  The Rollup `external` predicate derives from the union of `dependencies` and
+  `peerDependencies`, matched by prefix. A hand-written list silently inlines a transitive
+  dependency the moment an upstream package adds one.
+- P2: CI asserts that every bare import specifier in a built `dist` is either relative or
+  declared in that package's `package.json`. This closes the whole class rather than the cases
+  someone remembered.
+- P3: CodeMirror packages are `dependencies` of the editor with caret ranges, not
+  `peerDependencies` and not pinned. Consumers should not have to install a dozen packages,
+  and pinning exact versions guarantees duplicates in a consumer tree that has any other
+  CodeMirror-based dependency.
+- P4: A package that must resolve to a single runtime instance ships a re-export subpath so
+  extension authors never install the underlying library themselves. For the editor this is
+  `@itguy614/clean-ui-editor/codemirror`, re-exporting the CodeMirror surface a raw-tier plugin
+  needs plus its types, documented as the supported way to author one.
+- P5: Single-instance violations are detected, not documented and hoped for. Two layers: at
+  runtime, stamp identity on a versioned global on first editor construction and emit a
+  developer warning when it differs, translating CodeMirror's `Unrecognized extension value`
+  error into a message naming the fix (Vite `resolve.dedupe`, pnpm `overrides`); in CI, assert
+  the fixture app's build contains exactly one copy. The same technique applies to clean-ui,
+  whose module-scope singletons (injection keys, icon registry, density) fail silently rather
+  than loudly when duplicated.
+- P6: A satellite package depends on clean-ui through a caret peer range (`^1.2.0`), never
+  `>=`, which would assert compatibility with majors that do not exist yet. It additionally
+  lists clean-ui as a `devDependency` at `workspace:*`, because a peer entry alone does not
+  make pnpm link it or order the builds.
+
+### Verification
+
+- P7: A consumer fixture job in CI packs every published package with `pnpm pack`, installs the
+  tarballs into a throwaway Vite and Vue application using **npm** rather than the pnpm
+  workspace — which is how the real consumers install — builds it, and asserts against the
+  output. This is the only place the `exports` map, peer resolution and published file list are
+  exercised at all.
+- P8: The fixture job's assertions are the package guarantees, expressed mechanically: the core
+  entry's chunks contain no markdown-to-HTML renderer or sanitiser; importing a subpath adds
+  them; exactly one copy of each single-instance dependency; the `@phosphor-icons/vue` barrel is
+  absent; and gzip totals fall within a committed budget.
+- P9: Bundle budgets live in a committed file and fail CI on regression. A budget that is only
+  documented gates nothing.
+- P10: Test environments match what is under test. Alongside the existing jsdom project:
+  a `node`-environment project for server-rendering assertions, which cannot be made in jsdom;
+  and a real-browser runner for behaviour that depends on layout, selection or input method.
+  Shared setup provides the polyfills a DOM-dependent editor needs to mount in jsdom at all
+  (`Range.prototype.getBoundingClientRect` and `getClientRects`), because their absence looks
+  like "this cannot be tested" rather than a missing stub.
+- P11: Resolution policy lives in one place. The alias list mapping published package names to
+  workspace source is a shared module consumed by every docs app and test setup, so two apps
+  cannot disagree and quietly load two copies of clean-ui.
+
+### Release
+
+- P12: Versions are **lockstep**: all published packages share one version number, the root
+  `VERSION` file and the root `CHANGELOG.md`, and tags stay `vMAJOR.MINOR.PATCH`. Changelog
+  entries name the package they affect when it is not clean-ui.
+- P13: The publish job is a matrix over publishable packages, keeping the existing `npm view`
+  idempotency check.
+- P14: A package whose files have not changed since the previous release tag is skipped by the
+  publish matrix. Under lockstep its version number moves anyway, so the version check alone
+  would republish a byte-identical artifact.
+- P15: A new package joins at the current shared version rather than starting at 1.0.0. Its
+  maturity is communicated in its documentation, not in a version number it does not control.
+- P16: A satellite release that depends on a new clean-ui seam must not reach `master` before
+  the clean-ui release providing it. The peer range resolves against the registry, not the
+  workspace, so the ordering is real rather than a formality.
+- P17: CI builds and tests the whole workspace topologically (`pnpm -r`), across the existing
+  Node version matrix, rather than filtering to one package. A green pipeline that does not
+  look at a new package is worse than no pipeline.
+- P18: GitHub Pages hosts one site per repository, so multiple docs apps are composed into a
+  single artifact — each built with its own base path into a subdirectory, each with its own
+  `404.html` — and all are rebuilt on every deploy.
+
+### Conventions this supersedes
+
+- P19: `CLAUDE.md`'s component checklist says to register new components in the plugin's global
+  `app.component()` install. A satellite package with a heavy dependency graph must **not** do
+  this: a global install puts its entire dependency tree in every consumer's main bundle and
+  defeats route-level code splitting. Named imports only, with an async-component example in
+  the docs. `CLAUDE.md` should record the exception.
+
+## Acceptance Criteria
+
+- [ ] Adding a dependency to a published package requires no change to any `external` list, and
+      CI fails if a built `dist` imports something undeclared
+- [ ] The fixture app builds from packed tarballs installed with npm, and its assertions fail
+      when a renderer, an icon barrel, or a second copy of a single-instance dependency is
+      introduced
+- [ ] A deliberate bundle regression fails CI against the committed budget
+- [ ] A DOM-dependent editor component mounts in the jsdom project; server-rendering assertions
+      run in the node project; the browser runner executes the layout- and input-dependent cases
+- [ ] Two docs apps resolve clean-ui through the same shared alias module, and a duplicate copy
+      is detected rather than silently tolerated
+- [ ] A release publishes only the packages whose files changed, at the shared version, with
+      correctly namespaced release notes
+- [ ] Both docs sites deploy from one Pages artifact, each reachable at its own base path
+- [ ] CI builds and tests every workspace package on every supported Node version
+
+## Known Gaps Not Addressed Here
+
+- There is no linter in this repository: no eslint, prettier or biome configuration exists, and
+  the root `lint` script matches no package script. Any acceptance criterion asserting "linting
+  passes" is currently false. Worth resolving before a second package doubles the surface, but
+  it is a separate piece of work.
+- `scripts/check-contrast.mjs` reads clean-ui's `theme.css` with a hardcoded token pair list.
+  Extending the audit to a second package's tokens is real work, and any requirement claiming
+  a satellite package is "verified by the same contrast audit" depends on it.
+- `CONTRIBUTING.md` still states the docs site consumes the built library; it consumes source
+  via an alias.
+
+## References
+
+- CodeMirror duplicate-instance failure mode:
+  https://discuss.codemirror.net/t/uncaught-error-unrecognized-extension-value-in-extension-set-object-object-this-sometimes-happens-because-multiple-instances-of-codemirror-state-are-loaded-breaking-instanceof-checks/7898
+- Prior art in this repository for guarantees that only broke in consumer builds: issues #42
+  (icon barrel defeating tree-shaking) and #62 (stylesheet shipping Tailwind utilities)
+- Existing workflows: `.github/workflows/{ci,publish-npm,deploy-docs}.yml`


### PR DESCRIPTION
Documentation only — 26 files, no code. Output of a design conversation plus a DX review, an architecture review, and a prototype spike.

## What's here

| Document | Purpose |
| --- | --- |
| `docs/features/markdown-editor.md` | The editor: what it is, why, 44 FRs and 12 NFRs |
| `docs/platform/multi-package-build-and-release.md` | What this repo needs before a second published package exists — applies to any future satellite |
| `docs/plans/clean-ui-1.2-seams/` | 25 tasks, 4 phases: the prerequisite release |
| `docs/plans/markdown-editor-phase-1/` | 44 tasks, 7 phases: the editor's v1 |

## The design in one paragraph

`@itguy614/clean-ui-editor`, a markdown editor where **markdown text is the document** and CodeMirror 6 provides the buffer. Syntax markers hide until the caret enters the construct — construct-level for a pointer, whole-line for touch — so there is no markdown-to-document conversion and therefore no round-trip fidelity to lose; source mode is the same buffer with decorations off. A plugin API whose declarative tier is expressive enough that every built-in formatting action uses it. An injectable `render` adapter, so no markdown-to-HTML renderer or sanitiser lands in the core bundle at any phase. A construct policy where excluding a plugin means the construct cannot enter the document, not merely that its button is hidden.

## Two things that gate the work

**clean-ui 1.2.0 must be published before the editor is.** Three seams the editor cannot fake do not exist in 1.1.0: `CuiMessages` is a closed interface so a satellite's message namespace isn't typable; there's no exported `version` for mismatch detection; and there's no colour-scheme signal, which matters because CodeMirror fixes its dark base theme when configuration is built while clean-ui's dark mode is a runtime class on an arbitrary ancestor. The peer range resolves against the registry, not the workspace, so this ordering is real.

**The release and CI machinery is single-package by construction.** Hardcoded `working-directory`, one changelog extraction, `v$VERSION` tags, `--filter @itguy614/clean-ui` in three places, and a Pages job that uploads one app's `dist`. Under the lockstep versioning decision this is narrower than independent versioning would have been, but the publish job still becomes a matrix with a changed-files guard, and CI has to look at more than one package.

## Prototype evidence, not estimates

A spike (built, measured, then deleted) validated the four assumptions that could have invalidated the approach — reveal behaviour, accessibility-tree exposure, touch granularity and IME composition — in headless Chrome against a built bundle. It also replaced the guessed bundle budget with a measured one and produced the most actionable finding in the set:

| Markdown language strategy | Editor stack, gzip |
| --- | --- |
| `@codemirror/lang-markdown` (the obvious import) | 171.2 kB |
| Built from `@lezer/markdown` + GFM | 98.8 kB |
| ...plus its list-continuation commands | 101.1 kB |
| ...plus autocomplete for the slash menu | **112.8 kB** |

`lang-markdown` statically depends on `lang-html`, dragging in the JavaScript and CSS grammars for embedded-HTML support this editor never uses. NFR1's budget is 130 kB, set from that.

The spike also caught two bugs now written into the spec: decorations must recompute when reveal granularity changes (a bare state effect sets none of the usual flags, so pointer-to-touch switching kept stale decorations), and hiding must not use `Decoration.replace()`, which removes characters from the DOM and so from the accessibility tree — only the accessibility-tree check catches that, no DOM assertion would.

What the spike did **not** prove is recorded as tasks rather than assumed: touch on a physical device, composition through a real input method, and how the exposed markdown sounds in a screen reader.

## Corrections to my own earlier drafts, kept visible

- **"A `required` empty editor blocks submit"** was unbuildable. `CuiForm` validates only through a resolver and has no field registration; `required` is presentational throughout clean-ui. The criterion now asserts parity with a sibling control instead.
- **"Linting passes"** was false — there is no linter in this repository. Struck rather than papered over, with the decision recorded so nobody helpfully adds one.
- **"Verified by the same contrast audit"** depends on generalising `check-contrast.mjs`, which reads one package's tokens with a hardcoded pair list. Now a task.

## Review notes

Worth your attention when reading:

- **Feature spec is 437 lines** against the format's 400-line guideline. I applied the guideline's remedy once by splitting out the platform document; everything left is editor behaviour. The natural next cut is the plugin API into its own contract document (~60 lines, distinct audience), which I didn't do unilaterally.
- **Neither plan estimates time.** Editor phases 02 (reveal layer) and 03 (plugin system) hold the real uncertainty; the rest is mostly known shape.
- **Phase ordering encodes one deliberate rule:** the plugin system is built before any built-in plugin, so that if a built-in needs privileged access the tier is wrong and gets fixed — rather than the built-in quietly getting a special case, which is how the "no privileged internal paths" guarantee would rot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)