### PR TITLE
ci: fix publish-npm workflow so v1.2.0 actually publishes

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -87,9 +87,21 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # Each matrix package builds in its own isolated runner, so a package
+      # that depends on another workspace package (e.g. clean-ui-editor on
+      # clean-ui) can't rely on a sibling matrix job's dist having already
+      # been built — there's no shared artifact between them. `pkg...`
+      # (trailing dots) is pnpm's "this package plus its own workspace
+      # dependencies" filter — confirmed empirically (the *leading*-dots form,
+      # `...pkg`, is the opposite: this package plus its *dependents*) — so
+      # this builds clean-ui first when the matrix package is clean-ui-editor,
+      # and is a no-op broadening for clean-ui itself (no workspace deps).
+      # Reproduced the bare `--filter "pkg"` version's exact failure
+      # (`Cannot find module '@itguy614/clean-ui'`) in an isolated worktree
+      # before confirming this fixes it.
       - name: Build
         if: steps.version-check.outputs.publish == 'true' && steps.changed-check.outputs.changed == 'true'
-        run: pnpm --filter "${{ steps.version-check.outputs.name }}" build
+        run: pnpm --filter "${{ steps.version-check.outputs.name }}..." build
 
       - name: Publish to npm
         if: steps.version-check.outputs.publish == 'true' && steps.changed-check.outputs.changed == 'true'


### PR DESCRIPTION
## Summary
PR #80 merged v1.2.0 into master, but its `Publish to npm` run failed before actually publishing either package — confirmed neither `@itguy614/clean-ui` (still 1.1.0 on npm) nor `@itguy614/clean-ui-editor` (never published) went out.

Root cause: `publish-npm.yml`'s per-package matrix runs each package in a fully isolated runner. `clean-ui-editor`'s build step only built itself, with nothing building `@itguy614/clean-ui` first in that same job — so it failed to resolve `@itguy614/clean-ui`'s types, and the matrix's fail-fast behavior canceled the `clean-ui` job too.

This PR (already on develop, being promoted to master):
- Fixes `publish-npm.yml` to build each matrix package's own workspace dependencies first (`pnpm --filter "<pkg>..." build`), verified in an isolated worktree against the exact failure before applying.
- Also fixes an equivalent gap already found and fixed in `deploy-docs.yml` (apps/editor-docs's build needs `@itguy614/clean-ui-editor`'s dist too).

## Test plan
- [x] Reproduced the exact `Cannot find module '@itguy614/clean-ui'` failure in an isolated git worktree using the pre-fix workflow
- [x] Confirmed the fix builds `clean-ui` then `clean-ui-editor` successfully in the same isolated worktree
- [x] Confirmed `clean-ui`'s own matrix job is unaffected (no workspace deps to add)
- [ ] Once merged, `Publish to npm` should run on master and successfully publish both packages at v1.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)