### PR TITLE
fix(theme): stop useTheme stripping custom cui-theme-* / forcing mono on import

### DIFF
--- a/packages/clean-ui/package.json
+++ b/packages/clean-ui/package.json
@@ -51,7 +51,6 @@
     "./dist/icons/lazy.js",
     "./dist/duplicate-guard.js",
     "./src/duplicate-guard.ts",
-    "./dist/composables/useTheme.js",
     "./dist/composables/useDensity.js"
   ],
   "scripts": {

--- a/packages/clean-ui/src/composables/__tests__/useTheme.test.ts
+++ b/packages/clean-ui/src/composables/__tests__/useTheme.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { nextTick } from "vue";
+
+const root = () => document.documentElement;
+const hasClass = (c: string) => root().classList.contains(c);
+const anyThemeClass = () => [...root().classList].some((c) => c.startsWith("cui-theme-"));
+
+// useTheme is a module-singleton (shared activeTheme + a one-time restore), so
+// each test gets a fresh module via vi.resetModules() + dynamic import.
+async function freshUseTheme() {
+  vi.resetModules();
+  return (await import("../useTheme")).useTheme;
+}
+
+describe("useTheme (#85)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    root().className = "";
+  });
+
+  it("does not strip a consumer's custom cui-theme-* class", async () => {
+    root().classList.add("cui-theme-acme");
+    const useTheme = await freshUseTheme();
+    useTheme(); // engaging the composable must not touch the custom class
+    expect(hasClass("cui-theme-acme")).toBe(true);
+    expect(hasClass("cui-theme-mono")).toBe(false);
+  });
+
+  it("applies no theme class when nothing is stored (no-op default)", async () => {
+    const useTheme = await freshUseTheme();
+    const { theme } = useTheme();
+    expect(theme.value).toBe("default");
+    expect(anyThemeClass()).toBe(false);
+  });
+
+  it("restores a previously-stored theme on first use", async () => {
+    localStorage.setItem("cui-theme", "violet");
+    const useTheme = await freshUseTheme();
+    const { theme } = useTheme();
+    expect(theme.value).toBe("violet");
+    expect(hasClass("cui-theme-violet")).toBe(true);
+  });
+
+  it("setTheme swaps preset classes but leaves a custom class intact", async () => {
+    root().classList.add("cui-theme-acme");
+    const useTheme = await freshUseTheme();
+    const { setTheme } = useTheme();
+
+    setTheme("forest");
+    await nextTick();
+    expect(hasClass("cui-theme-forest")).toBe(true);
+    expect(hasClass("cui-theme-acme")).toBe(true);
+
+    setTheme("teal");
+    await nextTick();
+    expect(hasClass("cui-theme-teal")).toBe(true);
+    expect(hasClass("cui-theme-forest")).toBe(false); // old preset removed
+    expect(hasClass("cui-theme-acme")).toBe(true); // custom still survives
+  });
+
+  it("setTheme('default') removes preset classes and adds none", async () => {
+    const useTheme = await freshUseTheme();
+    const { setTheme } = useTheme();
+    setTheme("ruby");
+    await nextTick();
+    expect(hasClass("cui-theme-ruby")).toBe(true);
+    setTheme("default");
+    await nextTick();
+    expect(anyThemeClass()).toBe(false);
+  });
+});

--- a/packages/clean-ui/src/composables/useTheme.ts
+++ b/packages/clean-ui/src/composables/useTheme.ts
@@ -8,8 +8,8 @@ export interface ThemePreset {
 }
 
 export const THEME_PRESETS: ThemePreset[] = [
-  { id: "mono", label: "Mono", description: "Monochrome — default theme" },
-  { id: "default", label: "Navy", description: "Navy blue" },
+  { id: "mono", label: "Mono", description: "Monochrome" },
+  { id: "default", label: "Navy", description: "Navy blue (base scale)" },
   { id: "forest", label: "Forest", description: "Natural green" },
   { id: "amber", label: "Amber", description: "Warm orange with warm grays" },
   { id: "azure", label: "Azure", description: "Vibrant blue" },
@@ -21,11 +21,18 @@ export const THEME_PRESETS: ThemePreset[] = [
 const STORAGE_KEY = "cui-theme";
 const CLASS_PREFIX = "cui-theme-";
 
+// Only the classes clean-ui itself may add. `applyTheme` strips these and no
+// others, so a consuming app's own `cui-theme-<brand>` class on <html> — a
+// documented way to ship a custom palette — is never removed (issue #85).
+const PRESET_CLASSES = new Set(THEME_PRESETS.map((p) => `${CLASS_PREFIX}${p.id}`));
+
 function loadTheme(): string {
-  return safeGetItem(STORAGE_KEY) ?? "mono";
+  // No-op default: with nothing stored, don't force a theme — "default" adds no
+  // class, leaving whatever the consumer set (their own theme, or the base scale).
+  return safeGetItem(STORAGE_KEY) ?? "default";
 }
 
-// Shared reactive state
+// Shared reactive singleton — all components see the same theme.
 const activeTheme = ref<string>(loadTheme());
 
 function applyTheme(themeId: string) {
@@ -33,7 +40,7 @@ function applyTheme(themeId: string) {
 
   const root = document.documentElement;
   for (const cls of Array.from(root.classList)) {
-    if (cls.startsWith(CLASS_PREFIX)) {
+    if (PRESET_CLASSES.has(cls)) {
       root.classList.remove(cls);
     }
   }
@@ -43,19 +50,34 @@ function applyTheme(themeId: string) {
   }
 }
 
-// Apply on init (browser only)
-applyTheme(activeTheme.value);
-
+// Persist + reflect changes. Registered at module scope, but the callback only
+// runs when the theme actually *changes* (via setTheme) — so merely importing
+// the library never rewrites <html>. This is the fix for the import-time side
+// effect: no unconditional `applyTheme(...)` at module load.
 watch(activeTheme, (newTheme) => {
   applyTheme(newTheme);
   safeSetItem(STORAGE_KEY, newTheme);
 });
+
+// Re-apply a previously-stored selection the first time the composable is used
+// (browser only) — on demand, not as an import side effect. Only applies when
+// the user explicitly stored a theme; otherwise the document is left untouched.
+let restored = false;
+function restoreStoredTheme() {
+  if (restored) return;
+  restored = true;
+  if (safeGetItem(STORAGE_KEY) != null) {
+    applyTheme(activeTheme.value);
+  }
+}
 
 /**
  * Theme management composable.
  * Shared singleton — all components see the same theme.
  */
 export function useTheme() {
+  restoreStoredTheme();
+
   function setTheme(themeId: string) {
     activeTheme.value = themeId;
   }


### PR DESCRIPTION
`useTheme` ran `applyTheme()` as a module-load side effect that stripped **every** `cui-theme-*` class and forced `mono` — so merely importing the barrel deleted a consuming app's own `cui-theme-<brand>` class and reverted its palette app-wide.

## Root cause
The strip/force/import-apply behavior existed in 1.0.1 too, but `useTheme.js` was **not** in `sideEffects` then, so bundlers tree-shook it away for apps that don't use it. In 1.2.x it was **added** to `sideEffects`, making it non-tree-shakeable — now it runs on every barrel import.

## Fix
- `applyTheme` strips **only clean-ui's own preset classes**, so a consumer's `cui-theme-<brand>` survives.
- **No `applyTheme` at module load.** A stored theme is restored lazily on first `useTheme()` call, and only when one is actually stored — importing never rewrites `<html>`.
- **No-op default:** with nothing stored, apply no class (base Navy) instead of forcing `mono`. (Per the chosen behavior — this changes the untouched out-of-box look from Mono → Navy, matching the documented Navy-is-default.)
- **Removed `useTheme.js` from `sideEffects`** — safe now that import touches no DOM; restores 1.0.1 tree-shakeability.
- 5 tests (custom-class survival, no-op default, restore-on-use, preset swaps).

Build + jsdom suite green (446 passed). *(The SSR suite can't run in my sandbox — `@vue/server-renderer` isn't installed here — but the change is SSR-safe: module load only does a storage-guarded `ref` + a `watch`, no `document` access.)*

### Sibling note
`useDensity` has the **same latent pattern** (import-time `applyDensity()` + strips all `cui-density-*`, also in `sideEffects`). Lower impact (no custom-brand-density convention), but worth a follow-up.

Closes #85