### PR TITLE
fix(editor): toolbar icons register from the component (not a droppable side effect)

### DIFF
--- a/packages/clean-ui-editor/src/components/CuiMarkdownEditor.vue
+++ b/packages/clean-ui-editor/src/components/CuiMarkdownEditor.vue
@@ -1,3 +1,12 @@
+<script lang="ts">
+// Register the built-in toolbar glyphs as part of THIS component's module graph,
+// so they always register when the editor is used — not via a bare barrel side
+// effect a consumer's bundler can tree-shake away (which left them showing "?").
+// Runs once, at module evaluation. See issue #86.
+import { registerEditorIcons } from "../icons";
+registerEditorIcons();
+</script>
+
 <script setup lang="ts">
 import { ref, computed, onMounted, onBeforeUnmount, watch, useTemplateRef } from "vue";
 import { EditorView, keymap, drawSelection, placeholder as placeholderExtension } from "@codemirror/view";

--- a/packages/clean-ui-editor/src/icons.ts
+++ b/packages/clean-ui-editor/src/icons.ts
@@ -18,26 +18,37 @@ import {
 } from "@phosphor-icons/vue";
 
 /**
- * Registers every icon the built-in formatting plugins reference by name
- * (task 4.1.1: "Icons used are registered by this package, so they render in
- * a consumer app rather than falling back to a placeholder glyph"). Statically
- * imported, so only these ~15 icons are bundled — not clean-ui's lazy,
+ * Registers every icon the built-in formatting plugins reference by name, so
+ * they render in a consumer app rather than falling back to the `?` placeholder.
+ * Statically imported, so only these ~15 icons are bundled — not clean-ui's lazy,
  * any-name resolver.
+ *
+ * Exposed as a **function that CuiMarkdownEditor calls** (see issue #86) rather
+ * than a bare module-load side effect: a side-effect-only module can be proven
+ * unused and tree-shaken out of a consumer build even when listed in
+ * `sideEffects`, which left every toolbar button rendering `?`. A value the
+ * component references cannot be dropped. Idempotent — safe to call more than once.
  */
-registerIcons({
-  bold: PhTextB,
-  italic: PhTextItalic,
-  strikethrough: PhTextStrikethrough,
-  code: PhCode,
-  "heading-1": PhTextHOne,
-  "heading-2": PhTextHTwo,
-  "heading-3": PhTextHThree,
-  "list-bulleted": PhListBullets,
-  "list-numbered": PhListNumbers,
-  "list-task": PhListChecks,
-  blockquote: PhQuotes,
-  "code-block": PhCodeBlock,
-  "horizontal-rule": PhMinus,
-  link: PhLink,
-  image: PhImage,
-});
+let registered = false;
+
+export function registerEditorIcons(): void {
+  if (registered) return;
+  registered = true;
+  registerIcons({
+    bold: PhTextB,
+    italic: PhTextItalic,
+    strikethrough: PhTextStrikethrough,
+    code: PhCode,
+    "heading-1": PhTextHOne,
+    "heading-2": PhTextHTwo,
+    "heading-3": PhTextHThree,
+    "list-bulleted": PhListBullets,
+    "list-numbered": PhListNumbers,
+    "list-task": PhListChecks,
+    blockquote: PhQuotes,
+    "code-block": PhCodeBlock,
+    "horizontal-rule": PhMinus,
+    link: PhLink,
+    image: PhImage,
+  });
+}

--- a/packages/clean-ui-editor/src/index.ts
+++ b/packages/clean-ui-editor/src/index.ts
@@ -1,5 +1,4 @@
 import "./styles/editor.css";
-import "./icons";
 
 export { default as CuiMarkdownEditor } from "./components/CuiMarkdownEditor.vue";
 export type { CuiMarkdownEditorProps, CuiMarkdownEditorMode } from "./components/CuiMarkdownEditor.vue";


### PR DESCRIPTION
Built-in editor toolbar icons rendered as `?` in consumer builds because the registration was a bare barrel side effect (`import "./icons"`) that gets tree-shaken away — even though `icons.js` is in `sideEffects`.

## Fix
Tie the registration to the component's own module graph so it can't be dropped:
- `icons.ts` now exports a **guarded `registerEditorIcons()`** function (no module-scope side effect).
- `CuiMarkdownEditor.vue` **calls it** from a module-scope `<script>` block — a value the used component references, so bundlers keep it. Runs whenever the editor loads (including the documented async `defineAsyncComponent` import).
- Removed the bare `import "./icons"` from the barrel; the re-exported component now owns it.

## Verification caveats
- **A unit test can't catch this.** Importing the source in jsdom always evaluates the side-effect module, so icons register fine in tests — the bug only manifests in a *tree-shaken consumer bundle*. That's why it slipped through.
- I **could not build/test the editor package locally** (this sandbox's editor `.bin` lacks `vite`/`vitest`). clean-ui (which exports `registerIcons`, unchanged) builds fine, and the change is small. Please watch the editor build/test jobs in CI, and ideally have the reporter re-verify in their consumer app (the only place the tree-shaking reproduces).

Closes #86