### PR TITLE
fix(time-picker): trigger honors size (height parity with CuiInput/CuiDatePicker)

### DIFF
--- a/packages/clean-ui/src/components/CuiTimePicker.vue
+++ b/packages/clean-ui/src/components/CuiTimePicker.vue
@@ -5,6 +5,7 @@ import CuiPopover from "./CuiPopover.vue";
 import CuiInputStepper from "./CuiInputStepper.vue";
 import CuiButton from "./CuiButton.vue";
 import CuiIcon from "./CuiIcon.vue";
+import { INPUT_SIZE_SCALE } from "../utils/sizing";
 import type { HideableProps, DisableableProps } from "../types/common";
 
 export type TimePickerFormat = "12" | "24";
@@ -36,6 +37,10 @@ const props = withDefaults(defineProps<CuiTimePickerProps>(), {
   disabled: false,
   hidden: false,
 });
+
+// Match CuiInput/CuiDatePicker's box for the trigger so pickers line up at the
+// same `size` when placed side by side (#87).
+const triggerDims = computed(() => INPUT_SIZE_SCALE[props.size]);
 
 const emit = defineEmits<{
   "update:modelValue": [value: string];
@@ -180,17 +185,19 @@ defineExpose({ el: rootEl, focus, blur });
     >
       <!-- Trigger input -->
       <div
+        class="cui-time-picker__trigger"
         :style="{
           display: 'inline-flex',
           alignItems: 'center',
           gap: 'calc(0.5rem * var(--cui-density-scale, 1))',
-          padding: 'calc(0.4375rem * var(--cui-density-scale, 1)) calc(0.625rem * var(--cui-density-scale, 1))',
+          height: triggerDims.height,
+          padding: `0 ${triggerDims.px}`,
           border: '1px solid var(--cui-border-strong, var(--cui-border))',
           borderRadius: 'var(--cui-button-radius, 0.375rem)',
           background: 'var(--cui-surface-base, white)',
           cursor: disabled ? 'default' : 'pointer',
           opacity: disabled ? '0.5' : '1',
-          fontSize: '0.875rem',
+          fontSize: triggerDims.fontSize,
           color: displayText ? 'var(--cui-text-body)' : 'var(--cui-text-tertiary)',
           minWidth: format === '24' ? '6rem' : '8rem',
         }"

--- a/packages/clean-ui/src/components/__tests__/CuiTimePicker.test.ts
+++ b/packages/clean-ui/src/components/__tests__/CuiTimePicker.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import CuiTimePicker from "../CuiTimePicker.vue";
+import { INPUT_SIZE_SCALE } from "../../utils/sizing";
+
+const triggerHeight = (size: "sm" | "md" | "lg") => {
+  const wrapper = mount(CuiTimePicker, { props: { size } });
+  const trigger = wrapper.get(".cui-time-picker__trigger");
+  return (trigger.element as HTMLElement).style.height;
+};
+
+describe("CuiTimePicker (#87)", () => {
+  it("trigger height honors the size prop (matches INPUT_SIZE_SCALE, like CuiInput/CuiDatePicker)", () => {
+    expect(triggerHeight("sm")).toBe(INPUT_SIZE_SCALE.sm.height);
+    expect(triggerHeight("md")).toBe(INPUT_SIZE_SCALE.md.height);
+    expect(triggerHeight("lg")).toBe(INPUT_SIZE_SCALE.lg.height);
+  });
+
+  it("sm and lg triggers are not the same height (size actually applies)", () => {
+    expect(triggerHeight("sm")).not.toBe(triggerHeight("lg"));
+  });
+});


### PR DESCRIPTION
`CuiTimePicker` accepted `size` but its trigger — a hand-rolled `<div>` with hard-coded padding/font — ignored it, so a `<CuiTimePicker size="sm">` rendered at a different height than a `<CuiDatePicker size="sm">` next to it (a start-date + start-time row is a common layout).

## Fix
Drive the trigger box from the shared **`INPUT_SIZE_SCALE`** (`height` + horizontal padding + `font-size`) — the exact tokens `CuiInput` uses (and `CuiDatePicker` gets via its `CuiMaskedInput` trigger). So `sm`/`md`/`lg` now produce identical heights across all three.

- Added a `.cui-time-picker__trigger` class as a styling/test hook.
- Tests assert the trigger height tracks `INPUT_SIZE_SCALE` for `sm`/`md`/`lg` and that `sm` ≠ `lg`.

Build + jsdom suite green (443 passed). *(The SSR suite can't run in my sandbox — `@vue/server-renderer` isn't installed here — unrelated to this change.)*

Reviewer note: worth a quick side-by-side eyeball of `CuiTimePicker` + `CuiDatePicker` at each size.

Closes #87