### PR TITLE
fix(popover): gate panel on isPositioned to kill the top-left open flash

### DIFF
--- a/packages/clean-ui/src/components/CuiPopover.vue
+++ b/packages/clean-ui/src/components/CuiPopover.vue
@@ -70,7 +70,7 @@ watch(
   },
 );
 
-const { referenceRef, floatingRef, arrowRef, floatingStyles, arrowStyle, currentSide } = usePopover({
+const { referenceRef, floatingRef, arrowRef, floatingStyles, arrowStyle, currentSide, isPositioned } = usePopover({
   placement: computed(() => props.placement),
   offsetDistance: computed(() => props.offset ?? 10),
   arrow: !props.noArrow,
@@ -188,7 +188,7 @@ const messages = useMessages();
       <div
         v-if="isVisible"
         ref="floatingRef"
-        :style="{ ...floatingStyles, ...panelStyle }"
+        :style="{ ...floatingStyles, ...panelStyle, visibility: isPositioned ? 'visible' : 'hidden' }"
         role="dialog"
         :aria-labelledby="headerId"
         @mouseenter="onPopoverMouseEnter"


### PR DESCRIPTION
A `CuiPopover` panel painted at the viewport **top-left (0,0)** for one frame before Floating UI positioned it, then snapped into place — a visible open flash across every popover-based component (date/time picker calendars/dropdowns, popover menus).

## Cause
On the first render after `isVisible` flips true, `useFloating` hasn't computed a position, so `floatingStyles` is the initial `{ top: 0, left: 0, translate(0,0) }`. The element paints top-left, then repositions next tick.

## Fix
Gate the panel with `visibility: isPositioned ? 'visible' : 'hidden'` (`isPositioned` was already exposed by `usePopover`). Floating UI still measures a `visibility:hidden` element (unlike `display:none`), so positioning happens while hidden and the panel only becomes visible once placed. Using `visibility` (not `opacity`) avoids conflicting with the existing `cui-scale-in` entrance animation, and doesn't change open/close timing.

## Notes
- **No unit test:** this is a paint-frame race jsdom can't reproduce (no real layout/frames). Verified against Floating UI's `isPositioned` contract; build + 441 tests green (no regression). Please eyeball a date/time picker open on a slower frame.
- `CuiDropdown`/`CuiSelect` use synchronous positioning (not affected). `CuiTooltip` also uses `usePopover` but a show-delay mitigates it — worth a follow-up if you ever see a tooltip flash.

Closes #88